### PR TITLE
Replace `golang.org/x/exp` with stdlib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,6 @@ require (
 	github.com/yuin/goldmark v1.7.8
 	go.uber.org/dig v1.18.0
 	go.uber.org/multierr v1.11.0
-	golang.org/x/exp v0.0.0-20250218142911-aa4b98e5adaa
 	golang.org/x/oauth2 v0.26.0
 	golang.org/x/sys v0.30.0
 	golang.org/x/term v0.29.0
@@ -112,6 +111,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.24.0 // indirect
 	go.opentelemetry.io/otel/metric v1.34.0 // indirect
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect
+	golang.org/x/exp v0.0.0-20250218142911-aa4b98e5adaa // indirect
 	golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 // indirect
 	golang.org/x/mod v0.23.0 // indirect
 	golang.org/x/net v0.35.0 // indirect

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"cmp"
 	"fmt"
 	"math"
 	"os"
@@ -13,7 +14,6 @@ import (
 	"github.com/mgutz/ansi"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/constraints"
 
 	"github.com/runmedev/runme/v3/internal/runner"
 	"github.com/runmedev/runme/v3/internal/runner/client"
@@ -462,6 +462,6 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func clamp[T constraints.Ordered](x, a, b T) T {
+func clamp[T cmp.Ordered](x, a, b T) T {
 	return min(b, max(a, x))
 }

--- a/internal/dockerexec/docker.go
+++ b/internal/dockerexec/docker.go
@@ -2,10 +2,9 @@ package dockerexec
 
 import (
 	"context"
-	"encoding/binary"
 	"encoding/hex"
 	"io"
-	"math/rand/v2"
+	"math/rand"
 	"time"
 
 	"github.com/docker/docker/api/types/filters"
@@ -35,9 +34,7 @@ func New(opts *Options) (*Docker, error) {
 		logger = zap.NewNop()
 	}
 
-	var seed [32]byte
-	binary.LittleEndian.PutUint64(seed[:], uint64(time.Now().UnixNano()))
-	rnd := rand.NewChaCha8(seed)
+	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	d := &Docker{
 		client:       c,
@@ -64,7 +61,7 @@ type Docker struct {
 	image        string
 
 	logger *zap.Logger
-	rnd    *rand.ChaCha8
+	rnd    *rand.Rand
 }
 
 func (d *Docker) CommandContext(ctx context.Context, program string, args ...string) *Cmd {

--- a/internal/runner/command_test.go
+++ b/internal/runner/command_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"slices"
 	"syscall"
 	"testing"
 	"time"
@@ -15,7 +16,6 @@ import (
 	"github.com/creack/pty"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 )
 
 func init() {

--- a/internal/runner/env_store.go
+++ b/internal/runner/env_store.go
@@ -2,10 +2,9 @@ package runner
 
 import (
 	"errors"
+	"slices"
 	"strings"
 	"sync"
-
-	"golang.org/x/exp/slices"
 )
 
 // Limited by windows

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -3,10 +3,10 @@ package runner
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 
 	"go.uber.org/zap"
-	"golang.org/x/exp/slices"
 
 	"github.com/runmedev/runme/v3/internal/lru"
 	"github.com/runmedev/runme/v3/internal/owl"

--- a/internal/ulid/generator.go
+++ b/internal/ulid/generator.go
@@ -1,32 +1,13 @@
 package ulid
 
 import (
-	"io"
-	"math/rand"
 	"regexp"
-	"sync"
 	"time"
 
 	"github.com/oklog/ulid/v2"
 )
 
-var (
-	entropy     io.Reader
-	entropyOnce sync.Once
-	generator   = DefaultGenerator
-)
-
-// DefaultEntropy returns a reader that generates ULID entropy.
-func DefaultEntropy() io.Reader {
-	entropyOnce.Do(func() {
-		rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-
-		entropy = &ulid.LockedMonotonicReader{
-			MonotonicReader: ulid.Monotonic(rng, 0),
-		}
-	})
-	return entropy
-}
+var generator = DefaultGenerator
 
 // IsULID checks if the given string is a valid ULID
 // ULID pattern:
@@ -56,7 +37,7 @@ func GenerateID() string {
 }
 
 func DefaultGenerator() string {
-	entropy := DefaultEntropy()
+	entropy := ulid.DefaultEntropy()
 	now := time.Now()
 	ts := ulid.Timestamp(now)
 	return ulid.MustNew(ts, entropy).String()

--- a/internal/ulid/generator.go
+++ b/internal/ulid/generator.go
@@ -2,8 +2,7 @@ package ulid
 
 import (
 	"io"
-	"math/rand/v2"
-	"encoding/binary"
+	"math/rand"
 	"regexp"
 	"sync"
 	"time"
@@ -18,13 +17,9 @@ var (
 )
 
 // DefaultEntropy returns a reader that generates ULID entropy.
-// The default entropy function utilizes math/rand.Rand, which is not safe for concurrent use by multiple goroutines.
-// Therefore, this function employs math/rand/v2 (supersedes x/exp/rand), as recommended by the authors of the library.
 func DefaultEntropy() io.Reader {
 	entropyOnce.Do(func() {
-		var seed [32]byte
-		binary.LittleEndian.PutUint64(seed[:], uint64(time.Now().UnixNano()))
-		rng := rand.NewChaCha8(seed)
+		rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 		entropy = &ulid.LockedMonotonicReader{
 			MonotonicReader: ulid.Monotonic(rng, 0),


### PR DESCRIPTION
These experimental packages are now available in the Go standard library.

1. `golang.org/x/exp/slices` -> `slices` (https://go.dev/doc/go1.21#slices)
2. `golang.org/x/exp/rand` -> `math/rand/v2` (https://go.dev/doc/go1.22#math_rand_v2)

`golang.org/x/exp/rand` has been deprecated and scheduled to be deleted.

Reference: https://github.com/golang/exp/commit/f9890c6ad9f380fd3cdb66a33843f522d4790e03