### PR TITLE
Guard against nil config passed by a client

### DIFF
--- a/internal/runnerv2service/service_execute.go
+++ b/internal/runnerv2service/service_execute.go
@@ -54,12 +54,17 @@ func (r *runnerService) Execute(srv runnerv2.RunnerService_ExecuteServer) error 
 			return err
 		}
 	}
-	if err := session.SetEnv(ctx, req.Config.Env...); err != nil {
+
+	cfg := req.GetConfig()
+	if cfg == nil {
+		return errors.New("request config cannot be nil")
+	}
+	if err := session.SetEnv(ctx, cfg.GetEnv()...); err != nil {
 		return err
 	}
 
 	exec, err := newExecution(
-		req.Config,
+		cfg,
 		proj,
 		session,
 		logger,
@@ -166,12 +171,17 @@ func (r *runnerService) ExecuteOneShot(req *runnerv2.ExecuteOneShotRequest, srv 
 			return err
 		}
 	}
-	if err := session.SetEnv(ctx, req.Config.Env...); err != nil {
+
+	cfg := req.GetConfig()
+	if cfg == nil {
+		return errors.New("request config cannot be nil")
+	}
+	if err := session.SetEnv(ctx, cfg.GetEnv()...); err != nil {
 		return err
 	}
 
 	exec, err := newExecution(
-		req.Config,
+		cfg,
 		proj,
 		session,
 		logger,

--- a/internal/runnerv2service/service_execute_test.go
+++ b/internal/runnerv2service/service_execute_test.go
@@ -59,6 +59,28 @@ func Test_matchesOpinionatedEnvVarNaming(t *testing.T) {
 	})
 }
 
+func TestRunnerServiceServerExecute_EmptyConfigErrors(t *testing.T) {
+	t.Parallel()
+
+	lis, stop := startRunnerServiceServer(t)
+	t.Cleanup(stop)
+
+	_, client := testutils.NewGRPCClientWithT(t, lis, runnerv2.NewRunnerServiceClient)
+
+	stream, err := client.Execute(context.Background())
+	require.NoError(t, err)
+
+	err = stream.Send(
+		&runnerv2.ExecuteRequest{},
+	)
+	require.NoError(t, err)
+
+	// Assert error response.
+	resp, err := stream.Recv()
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
 func TestRunnerServiceServerExecute_Response(t *testing.T) {
 	t.Parallel()
 
@@ -131,6 +153,24 @@ func TestRunnerServiceServerExecute_Response(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(0), resp.GetExitCode().GetValue())
 	assert.Nil(t, resp.GetPid())
+}
+
+func TestRunnerServiceServerExecuteOneShot_EmptyConfigErrors(t *testing.T) {
+	t.Parallel()
+
+	lis, stop := startRunnerServiceServer(t)
+	t.Cleanup(stop)
+
+	_, client := testutils.NewGRPCClientWithT(t, lis, runnerv2.NewRunnerServiceClient)
+
+	req := &runnerv2.ExecuteOneShotRequest{}
+	stream, err := client.ExecuteOneShot(context.Background(), req)
+	require.NoError(t, err)
+
+	// Assert error response.
+	resp, err := stream.Recv()
+	assert.Error(t, err)
+	assert.Nil(t, resp)
 }
 
 func TestRunnerServiceServerExecuteOneShot_Response(t *testing.T) {


### PR DESCRIPTION
Avoid nil pointer. Add tests to guard against regression.