### PR TITLE
Improvements to allow for better Dagger Shell UX

### DIFF
--- a/internal/notebook/resolver_test.go
+++ b/internal/notebook/resolver_test.go
@@ -117,6 +117,157 @@ EXTENSION()
 	}
 }
 
+func TestResolveDaggerShell_CellDaggerShell(t *testing.T) {
+	ctx := context.Background()
+
+	// fake notebook with mixed cells
+	daggerShellNotebook := &parserv1.Notebook{
+		Cells: []*parserv1.Cell{
+			{
+				Kind:  parserv1.CellKind_CELL_KIND_MARKUP,
+				Value: "## Mixed with System Shell as Default",
+			},
+			{
+				Kind:  parserv1.CellKind_CELL_KIND_MARKUP,
+				Value: "Dagger Call:",
+			},
+			{
+				Kind:       parserv1.CellKind_CELL_KIND_CODE,
+				LanguageId: "sh",
+				Metadata: map[string]string{
+					"runme.dev/id":            "01JPR4JA36V7M9ZTVZBZB2DPF5",
+					"runme.dev/name":          "dagger-core",
+					"runme.dev/nameGenerated": "true",
+				},
+				Value: "dagger core \\\n  git --url github.com/runmedev/vscode-runme \\\n    tag --name main \\\n    tree \\\n        file --path dagger/scripts/presetup.sh",
+			},
+			{
+				Kind:  parserv1.CellKind_CELL_KIND_MARKUP,
+				Value: "Dagger Shell:",
+			},
+			{
+				Kind:       parserv1.CellKind_CELL_KIND_CODE,
+				LanguageId: "sh",
+				Metadata: map[string]string{
+					"interpreter":             "dagger shell",
+					"name":                    "Presetup",
+					"runme.dev/id":            "01JPR4JA37X07H529VAC49HEZJ",
+					"runme.dev/name":          "Presetup",
+					"runme.dev/nameGenerated": "false",
+				},
+				Value: "git github.com/runmedev/vscode-runme |\n  tag main |\n  tree |\n    file dagger/scripts/presetup.sh",
+			},
+			{
+				Kind:       parserv1.CellKind_CELL_KIND_CODE,
+				LanguageId: "sh",
+				Metadata: map[string]string{
+					"interpreter":             "dagger shell",
+					"runme.dev/id":            "01JPR4JA37X07H529VADC0XFRF",
+					"runme.dev/name":          "echo-presetup",
+					"runme.dev/nameGenerated": "true",
+				},
+				Value: ".echo $(Presetup)",
+			},
+		},
+		Metadata: map[string]string{
+			"runme.dev/cacheId":         "01JPR4JA37X07H529VAG28EPBG",
+			"runme.dev/finalLineBreaks": "0",
+			"runme.dev/frontmatter":     "---\nterminalRows: 10\n---",
+			"runme.dev/id":              "01JPR4JA37X07H529VAG28EPBG",
+		},
+		Frontmatter: &parserv1.Frontmatter{
+			TerminalRows: "10",
+		},
+	}
+
+	resolver, err := NewResolver(WithNotebook(daggerShellNotebook))
+	require.NoError(t, err)
+
+	// Test that the resolver can resolve vanilla shell
+	script, err := resolver.ResolveDaggerShell(ctx, uint32(2))
+	require.NoError(t, err)
+	assert.Equal(t, "dagger core \\\n  git --url github.com/runmedev/vscode-runme \\\n    tag --name main \\\n    tree \\\n        file --path dagger/scripts/presetup.sh", script)
+
+	// Test that the resolver can resolve dagger shell, skipping vanilla shell cells
+	script, err = resolver.ResolveDaggerShell(ctx, uint32(4))
+	require.NoError(t, err)
+	assert.Equal(t, "Presetup()\n{\n  git github.com/runmedev/vscode-runme \\\n    | tag main \\\n    | tree \\\n    | file dagger/scripts/presetup.sh\n}\nDAGGER_01JPR4JA37X07H529VADC0XFRF()\n{\n  .echo $(Presetup)\n}\nPresetup\n", script)
+}
+
+func TestResolveDaggerShell_FrontmatterWithVanillaCells(t *testing.T) {
+	ctx := context.Background()
+
+	// fake notebook with mixed cells
+	daggerShellNotebook := &parserv1.Notebook{
+		Cells: []*parserv1.Cell{
+			{
+				Kind:  parserv1.CellKind_CELL_KIND_MARKUP,
+				Value: "## Mixed with Dagger Shell as Default",
+			},
+			{
+				Kind:  parserv1.CellKind_CELL_KIND_MARKUP,
+				Value: "Dagger Call:",
+			},
+			{
+				Kind:       parserv1.CellKind_CELL_KIND_CODE,
+				LanguageId: "sh",
+				Metadata: map[string]string{
+					"interpreter":             "bash",
+					"runme.dev/id":            "01JPR4JA36V7M9ZTVZBZB2DPF5",
+					"runme.dev/name":          "dagger-core",
+					"runme.dev/nameGenerated": "true",
+				},
+				Value: "dagger core \\\n  git --url github.com/runmedev/vscode-runme \\\n    tag --name main \\\n    tree \\\n        file --path dagger/scripts/presetup.sh",
+			},
+			{
+				Kind:  parserv1.CellKind_CELL_KIND_MARKUP,
+				Value: "Dagger Shell:",
+			},
+			{
+				Kind:       parserv1.CellKind_CELL_KIND_CODE,
+				LanguageId: "sh",
+				Metadata: map[string]string{
+					"name":                    "Presetup",
+					"runme.dev/id":            "01JPR4JA37X07H529VAC49HEZJ",
+					"runme.dev/name":          "Presetup",
+					"runme.dev/nameGenerated": "false",
+				},
+				Value: "git github.com/runmedev/vscode-runme |\n  tag main |\n  tree |\n    file dagger/scripts/presetup.sh",
+			},
+			{
+				Kind:       parserv1.CellKind_CELL_KIND_CODE,
+				LanguageId: "sh",
+				Metadata: map[string]string{
+					"runme.dev/id":            "01JPR4JA37X07H529VADC0XFRF",
+					"runme.dev/name":          "echo-presetup",
+					"runme.dev/nameGenerated": "true",
+				},
+				Value: ".echo $(Presetup)",
+			},
+		},
+		Metadata: map[string]string{
+			"runme.dev/frontmatter": "---\nrunme:\n  id: 01JJDCG2SQSGV0DP55XCR55AYM\n  version: v3\nshell: dagger shell\nterminalRows: 20\n---",
+		},
+		Frontmatter: &parserv1.Frontmatter{
+			TerminalRows: "20",
+			Shell:        "dagger shell",
+		},
+	}
+
+	resolver, err := NewResolver(WithNotebook(daggerShellNotebook))
+	require.NoError(t, err)
+
+	// Test that the resolver can resolve vanilla shell
+	script, err := resolver.ResolveDaggerShell(ctx, uint32(2))
+	require.NoError(t, err)
+	assert.Equal(t, "dagger core \\\n  git --url github.com/runmedev/vscode-runme \\\n    tag --name main \\\n    tree \\\n        file --path dagger/scripts/presetup.sh", script)
+
+	// Test that the resolver can resolve dagger shell, skipping vanilla shell cells
+	script, err = resolver.ResolveDaggerShell(ctx, uint32(4))
+	require.NoError(t, err)
+	assert.Equal(t, "Presetup()\n{\n  git github.com/runmedev/vscode-runme \\\n    | tag main \\\n    | tree \\\n    | file dagger/scripts/presetup.sh\n}\nDAGGER_01JPR4JA37X07H529VADC0XFRF()\n{\n  .echo $(Presetup)\n}\nPresetup\n", script)
+}
+
 func TestResolveDaggerShell_Source(t *testing.T) {
 	simpleSource := "---\nshell: dagger shell\n---\n\n```sh {\"name\":\"simple_dagger\",\"terminalRows\":\"18\"}\n### Exported in runme.dev as simple_dagger\ngit github.com/runmedev/runme |\n    head |\n    tree |\n    file examples/README.md\n```\n"
 
@@ -161,4 +312,121 @@ DAGGER_`
 	script, err := resolver.ResolveDaggerShell(ctx, uint32(0))
 	require.NoError(t, err)
 	require.Contains(t, script, stub)
+}
+
+func TestResolveDaggerShell_InvalidShellFunctionName(t *testing.T) {
+	ctx := context.Background()
+
+	// fake notebook with invalid name for dagger shell
+	invalidNameNotebook := &parserv1.Notebook{
+		Cells: []*parserv1.Cell{
+			{
+				Kind:       parserv1.CellKind_CELL_KIND_CODE,
+				LanguageId: "sh",
+				Metadata: map[string]string{
+					"runme.dev/id":            "01JPR4JA36V7M9ZTVZBZB2DPF5",
+					"name":                    "dagger-core",
+					"runme.dev/nameGenerated": "false",
+				},
+				Value: "git github.com/runmedev/runme |\n    head |\n    tree |\n    file examples/README.md",
+			},
+		},
+		Metadata: map[string]string{
+			"runme.dev/frontmatter": "---\nshell: dagger shell\n---",
+		},
+	}
+
+	resolver, err := NewResolver(WithNotebook(invalidNameNotebook))
+	require.NoError(t, err)
+
+	_, err = resolver.ResolveDaggerShell(ctx, uint32(0))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "dagger shell integration requires cell name to be a valid shell function name, got dagger-core")
+
+	// fake notebook with valid name for dagger shell
+	validNameNotebook := &parserv1.Notebook{
+		Cells: []*parserv1.Cell{
+			{
+				Kind:       parserv1.CellKind_CELL_KIND_CODE,
+				LanguageId: "sh",
+				Metadata: map[string]string{
+					"runme.dev/id":            "01JPR4JA36V7M9ZTVZBZB2DPF5",
+					"name":                    "ValidName",
+					"runme.dev/nameGenerated": "false",
+				},
+				Value: "git github.com/runmedev/runme |\n    head |\n    tree |\n    file examples/README.md",
+			},
+		},
+		Metadata: map[string]string{
+			"runme.dev/frontmatter": "---\nshell: dagger shell\n---",
+		},
+	}
+
+	resolver, err = NewResolver(WithNotebook(validNameNotebook))
+	require.NoError(t, err)
+
+	script, err := resolver.ResolveDaggerShell(ctx, uint32(0))
+	require.NoError(t, err)
+	require.Contains(t, script, "ValidName()\n{\n  git github.com/runmedev/runme \\\n    | head \\\n    | tree \\\n    | file examples/README.md\n}\nValidName\n")
+}
+
+func TestIsValidShellFunctionName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "valid simple name",
+			input:    "my_function",
+			expected: true,
+		},
+		{
+			name:     "valid name with numbers",
+			input:    "function123",
+			expected: true,
+		},
+		{
+			name:     "valid name starting with underscore",
+			input:    "_my_function",
+			expected: true,
+		},
+		{
+			name:     "valid name with mixed case",
+			input:    "MyFunction",
+			expected: true,
+		},
+		{
+			name:     "invalid name starting with number",
+			input:    "123function",
+			expected: false,
+		},
+		{
+			name:     "invalid name with hyphen",
+			input:    "my-function",
+			expected: false,
+		},
+		{
+			name:     "invalid name with space",
+			input:    "my function",
+			expected: false,
+		},
+		{
+			name:     "invalid name with special characters",
+			input:    "my@function",
+			expected: false,
+		},
+		{
+			name:     "empty name",
+			input:    "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isValidShellFunctionName(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }


### PR DESCRIPTION
1. Allow notebooks to have cells with different shells.
2. Specifically return an error when a cell/block/task name is not a valid shell function name (Dagger Shell only).