### PR TITLE
FIFO silently fails breaking session environment variables

### DIFF
--- a/internal/command/command_inline_shell.go
+++ b/internal/command/command_inline_shell.go
@@ -58,6 +58,7 @@ func (c *inlineShellCommand) Wait(ctx context.Context) error {
 			zap.Int("count", len(c.session.GetAllEnv())), // TODO(adamb): change to session.Size()
 		)
 
+		// todo(sebastian): in v1 we don't collect unless successful. what's correct?
 		cErr := c.collectEnv(ctx)
 
 		c.logger.Info(

--- a/internal/command/command_inline_shell_test.go
+++ b/internal/command/command_inline_shell_test.go
@@ -54,6 +54,7 @@ func TestInlineShellCommand_CollectEnv(t *testing.T) {
 		err = populateCmd.Wait(context.Background())
 		require.NoError(t, err)
 
+		// Check that the environment variable was set
 		pre, ok := sess.GetEnv("PRE_ENV")
 		assert.True(t, ok)
 		assert.Equal(t, "9", pre)
@@ -85,6 +86,7 @@ func TestInlineShellCommand_CollectEnv(t *testing.T) {
 		err = checkCmd.Wait(context.Background())
 		require.EqualError(t, err, "signal: killed")
 
+		// Check that environment variable previously set is present
 		pre, ok = sess.GetEnv("PRE_ENV")
 		assert.True(t, ok)
 		assert.Equal(t, "9", pre)

--- a/internal/command/env_collector_fifo_unix.go
+++ b/internal/command/env_collector_fifo_unix.go
@@ -71,17 +71,24 @@ func (c *envCollectorFifo) init() error {
 	}
 	c.readersGroup = &errgroup.Group{}
 
+	readData := func(path string) ([]string, error) {
+		env, err := c.read(path)
+		close(c.readersDone[path])
+		if len(env) > 0 && len(strings.Split(env[0], "=")) != 2 {
+			return nil, errors.New("invalid data read: env var format is incorrect")
+		}
+		return env, err
+	}
+
 	c.readersGroup.Go(func() error {
 		var err error
-		c.preEnv, err = c.read(c.prePath())
-		close(c.readersDone[c.prePath()])
+		c.preEnv, err = readData(c.prePath())
 		return err
 	})
 
 	c.readersGroup.Go(func() error {
 		var err error
-		c.postEnv, err = c.read(c.postPath())
-		close(c.readersDone[c.postPath()])
+		c.postEnv, err = readData(c.postPath())
 		return err
 	})
 


### PR DESCRIPTION
While https://github.com/stateful/runme/issues/635 fixed the original issue and no longer blocked execution, it led to invalid data being processed downstream that breaks sessions.

This is PR extends the tests to account for maintaining an existing env store while guarding against reading invalid data.