### PR TITLE
Allow prompting in Shell Mode but only explicitly

### DIFF
--- a/internal/command/program_resolver.go
+++ b/internal/command/program_resolver.go
@@ -146,9 +146,14 @@ func (r *ProgramResolver) Resolve(reader io.Reader, writer io.Writer, retention 
 		}
 
 		name := decl.Args[0].Name.Value
+		isSensitive := r.IsEnvSensitive(name)
 		originalValue, isPlaceholder := r.findOriginalValue(decl)
 		resolvedValue, hasResolvedValue := r.findEnvValue(name)
-		isSensitive := r.IsEnvSensitive(name)
+
+		if retention == RetentionLastRun {
+			resolvedValue = originalValue
+			hasResolvedValue = true
+		}
 
 		varResult := ProgramResolverVarResult{
 			Status:        ProgramResolverStatusUnresolved,

--- a/internal/command/program_resolver.go
+++ b/internal/command/program_resolver.go
@@ -127,7 +127,7 @@ func (r *ProgramResolver) Resolve(reader io.Reader, writer io.Writer, retention 
 
 	var decls []*syntax.DeclClause
 	modified := false
-	// If retention is not last run or mode is prompt all, walk the AST and modify the program
+	// If retention is last run or mode is not prompt all, don't walk the AST and leave the program untouched
 	if retention != RetentionLastRun || r.mode == ProgramResolverModePromptAll {
 		decls, modified, err = r.walk(f)
 		if err != nil {

--- a/internal/command/program_resolver_test.go
+++ b/internal/command/program_resolver_test.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"bytes"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -11,350 +10,282 @@ import (
 )
 
 func TestProgramResolverResolve(t *testing.T) {
-	testCases := []struct {
-		name                 string
-		program              string
-		resultFirst          *ProgramResolverResult
-		resultLast           *ProgramResolverResult
-		modifiedProgramFirst string
-		modifiedProgramLast  string
-	}{
-		{
-			name:    "no value",
-			program: `export TEST_NO_VALUE`,
-			resultFirst: &ProgramResolverResult{
-				ModifiedProgram: true,
-				Variables: []ProgramResolverVarResult{
-					{
-						Status: ProgramResolverStatusUnresolved,
-						Name:   "TEST_NO_VALUE",
-					},
-				},
-			},
-			resultLast: &ProgramResolverResult{
-				ModifiedProgram: false,
-				Variables: []ProgramResolverVarResult{
-					{
-						Status: ProgramResolverStatusResolved,
-						Name:   "TEST_NO_VALUE",
-						Value:  "",
-					},
-				},
-			},
-			modifiedProgramFirst: "# Managed env store retention strategy: first\n\n#\n# TEST_NO_VALUE set in managed env store\n# \"export TEST_NO_VALUE\"\n\n",
-			modifiedProgramLast:  "# Managed env store retention strategy: last\n\nexport TEST_NO_VALUE\n",
-		},
-		{
-			name:    "empty value",
-			program: `export TEST_EMPTY_VALUE=`,
-			resultFirst: &ProgramResolverResult{
-				ModifiedProgram: true,
-				Variables: []ProgramResolverVarResult{
-					{
-						Status: ProgramResolverStatusUnresolved,
-						Name:   "TEST_EMPTY_VALUE",
-					},
-				},
-			},
-			resultLast: &ProgramResolverResult{
-				ModifiedProgram: false,
-				Variables: []ProgramResolverVarResult{
-					{
-						Status: ProgramResolverStatusResolved,
-						Name:   "TEST_EMPTY_VALUE",
-						Value:  "",
-					},
-				},
-			},
-			modifiedProgramFirst: "# Managed env store retention strategy: first\n\n#\n# TEST_EMPTY_VALUE set in managed env store\n# \"export TEST_EMPTY_VALUE=\"\n\n",
-			modifiedProgramLast:  "# Managed env store retention strategy: last\n\nexport TEST_EMPTY_VALUE=\n",
-		},
-		{
-			name:    "string value",
-			program: `export TEST_STRING_VALUE=value`,
-			resultFirst: &ProgramResolverResult{
-				ModifiedProgram: true,
-				Variables: []ProgramResolverVarResult{
-					{
-						Status:        ProgramResolverStatusUnresolvedWithMessage,
-						Name:          "TEST_STRING_VALUE",
-						OriginalValue: "value",
-					},
-				},
-			},
-			resultLast: &ProgramResolverResult{
-				ModifiedProgram: false,
-				Variables: []ProgramResolverVarResult{
-					{
-						Status:        ProgramResolverStatusResolved,
-						Name:          "TEST_STRING_VALUE",
-						OriginalValue: "value",
-						Value:         "value",
-					},
-				},
-			},
-			modifiedProgramFirst: "# Managed env store retention strategy: first\n\n#\n# TEST_STRING_VALUE set in managed env store\n# \"export TEST_STRING_VALUE=value\"\n\n",
-			modifiedProgramLast:  "# Managed env store retention strategy: last\n\nexport TEST_STRING_VALUE=value\n",
-		},
-		{
-			name:    "string value with equal sign",
-			program: `export TEST_STRING_VALUE_WITH_EQUAL_SIGN=part1=part2`,
-			resultFirst: &ProgramResolverResult{
-				ModifiedProgram: true,
-				Variables: []ProgramResolverVarResult{
-					{
-						Status:        ProgramResolverStatusUnresolvedWithMessage,
-						Name:          "TEST_STRING_VALUE_WITH_EQUAL_SIGN",
-						OriginalValue: "part1=part2",
-					},
-				},
-			},
-			resultLast: &ProgramResolverResult{
-				ModifiedProgram: false,
-				Variables: []ProgramResolverVarResult{
-					{
-						Status:        ProgramResolverStatusResolved,
-						Name:          "TEST_STRING_VALUE_WITH_EQUAL_SIGN",
-						OriginalValue: "part1=part2",
-						Value:         "part1=part2",
-					},
-				},
-			},
-			modifiedProgramFirst: "# Managed env store retention strategy: first\n\n#\n# TEST_STRING_VALUE_WITH_EQUAL_SIGN set in managed env store\n# \"export TEST_STRING_VALUE_WITH_EQUAL_SIGN=part1=part2\"\n\n",
-			modifiedProgramLast:  "# Managed env store retention strategy: last\n\nexport TEST_STRING_VALUE_WITH_EQUAL_SIGN=part1=part2\n",
-		},
-		{
-			name:    "string double quoted value empty",
-			program: `export TEST_STRING_DBL_QUOTED_VALUE_EMPTY=""`,
-			resultFirst: &ProgramResolverResult{
-				ModifiedProgram: true,
-				Variables: []ProgramResolverVarResult{
-					{
-						Status: ProgramResolverStatusUnresolved,
-						Name:   "TEST_STRING_DBL_QUOTED_VALUE_EMPTY",
-					},
-				},
-			},
-			resultLast: &ProgramResolverResult{
-				ModifiedProgram: false,
-				Variables: []ProgramResolverVarResult{
-					{
-						Status: ProgramResolverStatusResolved,
-						Name:   "TEST_STRING_DBL_QUOTED_VALUE_EMPTY",
-						Value:  "",
-					},
-				},
-			},
-			modifiedProgramFirst: "# Managed env store retention strategy: first\n\n#\n# TEST_STRING_DBL_QUOTED_VALUE_EMPTY set in managed env store\n# \"export TEST_STRING_DBL_QUOTED_VALUE_EMPTY=\\\"\\\"\"\n\n",
-			modifiedProgramLast:  "# Managed env store retention strategy: last\n\nexport TEST_STRING_DBL_QUOTED_VALUE_EMPTY=\"\"\n",
-		},
-		{
-			name:    "string double quoted value",
-			program: `export TEST_STRING_DBL_QUOTED_VALUE="value"`,
-			resultFirst: &ProgramResolverResult{
-				ModifiedProgram: true,
-				Variables: []ProgramResolverVarResult{
-					{
-						Status:        ProgramResolverStatusUnresolvedWithPlaceholder,
-						Name:          "TEST_STRING_DBL_QUOTED_VALUE",
-						OriginalValue: "value",
-					},
-				},
-			},
-			resultLast: &ProgramResolverResult{
-				ModifiedProgram: false,
-				Variables: []ProgramResolverVarResult{
-					{
-						Status:        ProgramResolverStatusResolved,
-						Name:          "TEST_STRING_DBL_QUOTED_VALUE",
-						OriginalValue: "value",
-						Value:         "value",
-					},
-				},
-			},
-			modifiedProgramFirst: "# Managed env store retention strategy: first\n\n#\n# TEST_STRING_DBL_QUOTED_VALUE set in managed env store\n# \"export TEST_STRING_DBL_QUOTED_VALUE=\\\"value\\\"\"\n\n",
-			modifiedProgramLast:  "# Managed env store retention strategy: last\n\nexport TEST_STRING_DBL_QUOTED_VALUE=\"value\"\n",
-		},
-		{
-			name:    "string single quoted value empty",
-			program: `export TEST_STRING_SGL_QUOTED_VALUE_EMPTY=''`,
-			resultFirst: &ProgramResolverResult{
-				ModifiedProgram: true,
-				Variables: []ProgramResolverVarResult{
-					{
-						Status: ProgramResolverStatusUnresolved,
-						Name:   "TEST_STRING_SGL_QUOTED_VALUE_EMPTY",
-					},
-				},
-			},
-			resultLast: &ProgramResolverResult{
-				ModifiedProgram: false,
-				Variables: []ProgramResolverVarResult{
-					{
-						Status: ProgramResolverStatusResolved,
-						Name:   "TEST_STRING_SGL_QUOTED_VALUE_EMPTY",
-						Value:  "",
-					},
-				},
-			},
-			modifiedProgramFirst: "# Managed env store retention strategy: first\n\n#\n# TEST_STRING_SGL_QUOTED_VALUE_EMPTY set in managed env store\n# \"export TEST_STRING_SGL_QUOTED_VALUE_EMPTY=''\"\n\n",
-			modifiedProgramLast:  "# Managed env store retention strategy: last\n\nexport TEST_STRING_SGL_QUOTED_VALUE_EMPTY=''\n",
-		},
-		{
-			name:    "string single quoted value",
-			program: `export TEST_STRING_SGL_QUOTED_VALUE='value'`,
-			resultFirst: &ProgramResolverResult{
-				ModifiedProgram: true,
-				Variables: []ProgramResolverVarResult{
-					{
-						Status:        ProgramResolverStatusUnresolvedWithPlaceholder,
-						Name:          "TEST_STRING_SGL_QUOTED_VALUE",
-						OriginalValue: "value",
-					},
-				},
-			},
-			resultLast: &ProgramResolverResult{
-				ModifiedProgram: false,
-				Variables: []ProgramResolverVarResult{
-					{
-						Status:        ProgramResolverStatusResolved,
-						Name:          "TEST_STRING_SGL_QUOTED_VALUE",
-						OriginalValue: "value",
-						Value:         "value",
-					},
-				},
-			},
-			modifiedProgramFirst: "# Managed env store retention strategy: first\n\n#\n# TEST_STRING_SGL_QUOTED_VALUE set in managed env store\n# \"export TEST_STRING_SGL_QUOTED_VALUE='value'\"\n\n",
-			modifiedProgramLast:  "# Managed env store retention strategy: last\n\nexport TEST_STRING_SGL_QUOTED_VALUE='value'\n",
-		},
-		{
-			name:    "shell-escaped prompt message",
-			program: `export TYPE=[Guest type \(hyperv,proxmox,openstack\)]`,
-			resultFirst: &ProgramResolverResult{
-				ModifiedProgram: true,
-				Variables: []ProgramResolverVarResult{
-					{
-						Status:        ProgramResolverStatusUnresolvedWithMessage,
-						Name:          "TYPE",
-						OriginalValue: "[Guest type (hyperv,proxmox,openstack)]",
-					},
-				},
-			},
-			resultLast: &ProgramResolverResult{
-				ModifiedProgram: false,
-				Variables: []ProgramResolverVarResult{
-					{
-						Status:        ProgramResolverStatusResolved,
-						Name:          "TYPE",
-						OriginalValue: "[Guest type (hyperv,proxmox,openstack)]",
-						Value:         "[Guest type (hyperv,proxmox,openstack)]",
-					},
-				},
-			},
-			modifiedProgramFirst: "# Managed env store retention strategy: first\n\n#\n# TYPE set in managed env store\n# \"export TYPE=[Guest type \\\\(hyperv,proxmox,openstack\\\\)]\"\n\n",
-			modifiedProgramLast:  "# Managed env store retention strategy: last\n\nexport TYPE=[Guest type \\(hyperv,proxmox,openstack\\)]\n",
-		},
-		{
-			name:                 "parameter expression",
-			program:              `export TEST_PARAM_EXPR=${TEST:7:0}`,
-			resultFirst:          &ProgramResolverResult{},
-			resultLast:           &ProgramResolverResult{},
-			modifiedProgramFirst: "# Managed env store retention strategy: first\n\nexport TEST_PARAM_EXPR=${TEST:7:0}\n",
-			modifiedProgramLast:  "# Managed env store retention strategy: last\n\nexport TEST_PARAM_EXPR=${TEST:7:0}\n",
-		},
-		{
-			name:                 "arithmetic expression",
-			program:              `export TEST_ARITHM_EXPR=$(($z+3))`,
-			resultFirst:          &ProgramResolverResult{},
-			resultLast:           &ProgramResolverResult{},
-			modifiedProgramFirst: "# Managed env store retention strategy: first\n\nexport TEST_ARITHM_EXPR=$(($z + 3))\n",
-			modifiedProgramLast:  "# Managed env store retention strategy: last\n\nexport TEST_ARITHM_EXPR=$(($z + 3))\n",
-		},
-		{
-			name:                 "value expression",
-			program:              `export TEST_VALUE_EXPR=$(echo -n "value")`,
-			resultFirst:          &ProgramResolverResult{},
-			resultLast:           &ProgramResolverResult{},
-			modifiedProgramFirst: "# Managed env store retention strategy: first\n\nexport TEST_VALUE_EXPR=$(echo -n \"value\")\n",
-			modifiedProgramLast:  "# Managed env store retention strategy: last\n\nexport TEST_VALUE_EXPR=$(echo -n \"value\")\n",
-		},
-		{
-			name:                 "double quoted value expression",
-			program:              `export TEST_DBL_QUOTE_VALUE_EXPR="$(echo -n 'value')"`,
-			resultFirst:          &ProgramResolverResult{},
-			resultLast:           &ProgramResolverResult{},
-			modifiedProgramFirst: "# Managed env store retention strategy: first\n\nexport TEST_DBL_QUOTE_VALUE_EXPR=\"$(echo -n 'value')\"\n",
-			modifiedProgramLast:  "# Managed env store retention strategy: last\n\nexport TEST_DBL_QUOTE_VALUE_EXPR=\"$(echo -n 'value')\"\n",
-		},
-		{
-			name:                 "default value",
-			program:              `export TEST_DEFAULT_VALUE=${TEST_DEFAULT_VALUE:-value}`,
-			resultFirst:          &ProgramResolverResult{},
-			resultLast:           &ProgramResolverResult{},
-			modifiedProgramFirst: "# Managed env store retention strategy: first\n\nexport TEST_DEFAULT_VALUE=${TEST_DEFAULT_VALUE:-value}\n",
-			modifiedProgramLast:  "# Managed env store retention strategy: last\n\nexport TEST_DEFAULT_VALUE=${TEST_DEFAULT_VALUE:-value}\n",
-		},
+	testInputs := map[string]string{
+		"NoValue":     `export TEST_NO_VALUE`,
+		"EmptyValue":  `export TEST_EMPTY_VALUE=`,
+		"NakedValue":  `export TEST_STRING_VALUE=value`,
+		"QuotedValue": `export TEST_STRING_VALUE="value"`,
+		"ParamExpr":   `export TEST_PARAM_EXPR=${TEST:7:0}`,
 	}
 
-	for _, tc := range testCases {
-		strategies := []struct {
-			name            string
-			strategy        Retention
-			modifiedProgram string
-			result          *ProgramResolverResult
-		}{
-			{
-				name:            "First",
-				strategy:        RetentionFirstRun,
-				modifiedProgram: tc.modifiedProgramFirst,
-				result:          tc.resultFirst,
-			},
-			{
-				name:            "Last",
-				strategy:        RetentionLastRun,
-				modifiedProgram: tc.modifiedProgramLast,
-				result:          tc.resultLast,
-			},
-		}
+	type testOutput struct {
+		expectedOutput string
+		expectedResult *ProgramResolverResult
+	}
 
-		for _, s := range strategies {
-			t.Run(fmt.Sprintf("ProgramResolverModeAuto_%s_%s", s.name, tc.name), func(t *testing.T) {
-				r := NewProgramResolver(ProgramResolverModeAuto, []string{})
+	runTestCases := func(t *testing.T, suite string, mode ProgramResolverMode, strategy Retention, outputs map[string]testOutput) {
+		t.Helper()
+		for name, program := range testInputs {
+			t.Run(suite+"_"+name, func(t *testing.T) {
+				output := outputs[name]
+				r := NewProgramResolver(mode, []string{})
 				buf := bytes.NewBuffer(nil)
-				got, err := r.Resolve(strings.NewReader(tc.program), buf, s.strategy)
+				got, err := r.Resolve(strings.NewReader(program), buf, strategy)
 				require.NoError(t, err)
-				assert.EqualValues(t, s.modifiedProgram, buf.String())
-				if s.result != nil {
-					assert.EqualValues(t, s.result, got)
-				}
-			})
-
-			t.Run(fmt.Sprintf("ProgramResolverModeSkip_%s_%s", s.name, tc.name), func(t *testing.T) {
-				r := NewProgramResolver(ProgramResolverModeSkipAll, []string{})
-				buf := bytes.NewBuffer(nil)
-				got, err := r.Resolve(strings.NewReader(tc.program), buf, s.strategy)
-				require.NoError(t, err)
-				if s.strategy == RetentionFirstRun {
-					assert.EqualValues(t, tc.modifiedProgramFirst, buf.String())
-				} else {
-					assert.EqualValues(t, tc.modifiedProgramLast, buf.String())
-				}
-
-				if s.result != nil {
-					for i, v := range s.result.Variables {
-						v.Status = ProgramResolverStatusResolved
-						v.Value = v.OriginalValue
-						s.result.Variables[i] = v
-					}
-					assert.EqualValues(t, s.result, got)
-				} else {
-					// for last strategy script remains structurally unchanged
-					assert.Len(t, got.Variables, 0)
-					assert.False(t, got.ModifiedProgram)
-				}
+				assert.EqualValues(t, output.expectedOutput, buf.String())
+				assert.EqualValues(t, output.expectedResult, got)
 			})
 		}
 	}
+
+	runTestCases(t, "Auto_FirstRun",
+		ProgramResolverModeAuto,
+		RetentionFirstRun,
+		map[string]testOutput{
+			"NoValue": {
+				expectedOutput: "# Managed env store retention strategy: first\n\n#\n# TEST_NO_VALUE set in managed env store\n# \"export TEST_NO_VALUE\"\n\n",
+				expectedResult: &ProgramResolverResult{
+					ModifiedProgram: true,
+					Variables: []ProgramResolverVarResult{
+						{
+							Status: ProgramResolverStatusUnresolved,
+							Name:   "TEST_NO_VALUE",
+						},
+					},
+				},
+			},
+			"EmptyValue": {
+				expectedOutput: "# Managed env store retention strategy: first\n\n#\n# TEST_EMPTY_VALUE set in managed env store\n# \"export TEST_EMPTY_VALUE=\"\n\n",
+				expectedResult: &ProgramResolverResult{
+					ModifiedProgram: true,
+					Variables: []ProgramResolverVarResult{
+						{
+							Status: ProgramResolverStatusUnresolved,
+							Name:   "TEST_EMPTY_VALUE",
+						},
+					},
+				},
+			},
+			"NakedValue": {
+				expectedOutput: "# Managed env store retention strategy: first\n\n#\n# TEST_STRING_VALUE set in managed env store\n# \"export TEST_STRING_VALUE=value\"\n\n",
+				expectedResult: &ProgramResolverResult{
+					ModifiedProgram: true,
+					Variables: []ProgramResolverVarResult{
+						{
+							Status:        ProgramResolverStatusUnresolvedWithMessage,
+							Name:          "TEST_STRING_VALUE",
+							OriginalValue: "value",
+						},
+					},
+				},
+			},
+			"QuotedValue": {
+				expectedOutput: "# Managed env store retention strategy: first\n\n#\n# TEST_STRING_VALUE set in managed env store\n# \"export TEST_STRING_VALUE=\\\"value\\\"\"\n\n",
+				expectedResult: &ProgramResolverResult{
+					ModifiedProgram: true,
+					Variables: []ProgramResolverVarResult{
+						{
+							Status:        ProgramResolverStatusUnresolvedWithPlaceholder,
+							Name:          "TEST_STRING_VALUE",
+							OriginalValue: "value",
+						},
+					},
+				},
+			},
+			"ParamExpr": {
+				expectedOutput: "# Managed env store retention strategy: first\n\nexport TEST_PARAM_EXPR=${TEST:7:0}\n",
+				expectedResult: &ProgramResolverResult{},
+			},
+		},
+	)
+
+	runTestCases(t, "SkipAll_FirstRun",
+		ProgramResolverModeSkipAll,
+		RetentionFirstRun,
+		map[string]testOutput{
+			"NoValue": {
+				expectedOutput: "# Managed env store retention strategy: first\n\n#\n# TEST_NO_VALUE set in managed env store\n# \"export TEST_NO_VALUE\"\n\n",
+				expectedResult: &ProgramResolverResult{
+					ModifiedProgram: true,
+					Variables: []ProgramResolverVarResult{
+						{
+							Status: ProgramResolverStatusResolved,
+							Name:   "TEST_NO_VALUE",
+						},
+					},
+				},
+			},
+			"EmptyValue": {
+				expectedOutput: "# Managed env store retention strategy: first\n\n#\n# TEST_EMPTY_VALUE set in managed env store\n# \"export TEST_EMPTY_VALUE=\"\n\n",
+				expectedResult: &ProgramResolverResult{
+					ModifiedProgram: true,
+					Variables: []ProgramResolverVarResult{
+						{
+							Status: ProgramResolverStatusResolved,
+							Name:   "TEST_EMPTY_VALUE",
+						},
+					},
+				},
+			},
+			"NakedValue": {
+				expectedOutput: "# Managed env store retention strategy: first\n\n#\n# TEST_STRING_VALUE set in managed env store\n# \"export TEST_STRING_VALUE=value\"\n\n",
+				expectedResult: &ProgramResolverResult{
+					ModifiedProgram: true,
+					Variables: []ProgramResolverVarResult{
+						{
+							Status:        ProgramResolverStatusResolved,
+							Name:          "TEST_STRING_VALUE",
+							OriginalValue: "value",
+							Value:         "value",
+						},
+					},
+				},
+			},
+			"QuotedValue": {
+				expectedOutput: "# Managed env store retention strategy: first\n\n#\n# TEST_STRING_VALUE set in managed env store\n# \"export TEST_STRING_VALUE=\\\"value\\\"\"\n\n",
+				expectedResult: &ProgramResolverResult{
+					ModifiedProgram: true,
+					Variables: []ProgramResolverVarResult{
+						{
+							Status:        ProgramResolverStatusResolved,
+							Name:          "TEST_STRING_VALUE",
+							OriginalValue: "value",
+							Value:         "value",
+						},
+					},
+				},
+			},
+			"ParamExpr": {
+				expectedOutput: "# Managed env store retention strategy: first\n\nexport TEST_PARAM_EXPR=${TEST:7:0}\n",
+				expectedResult: &ProgramResolverResult{},
+			},
+		},
+	)
+
+	runTestCases(t, "Auto_LastRun",
+		ProgramResolverModeAuto,
+		RetentionLastRun,
+		map[string]testOutput{
+			"NoValue": {
+				expectedOutput: "# Managed env store retention strategy: last\n\n#\n# TEST_NO_VALUE set in managed env store\n# \"export TEST_NO_VALUE\"\n\n",
+				expectedResult: &ProgramResolverResult{
+					ModifiedProgram: true,
+					Variables: []ProgramResolverVarResult{
+						{
+							Status: ProgramResolverStatusResolved,
+							Name:   "TEST_NO_VALUE",
+						},
+					},
+				},
+			},
+			"EmptyValue": {
+				expectedOutput: "# Managed env store retention strategy: last\n\n#\n# TEST_EMPTY_VALUE set in managed env store\n# \"export TEST_EMPTY_VALUE=\"\n\n",
+				expectedResult: &ProgramResolverResult{
+					ModifiedProgram: true,
+					Variables: []ProgramResolverVarResult{
+						{
+							Status: ProgramResolverStatusResolved,
+							Name:   "TEST_EMPTY_VALUE",
+						},
+					},
+				},
+			},
+			"NakedValue": {
+				expectedOutput: "# Managed env store retention strategy: last\n\n#\n# TEST_STRING_VALUE set in managed env store\n# \"export TEST_STRING_VALUE=value\"\n\n",
+				expectedResult: &ProgramResolverResult{
+					ModifiedProgram: true,
+					Variables: []ProgramResolverVarResult{
+						{
+							Status:        ProgramResolverStatusResolved,
+							Name:          "TEST_STRING_VALUE",
+							OriginalValue: "value",
+							Value:         "value",
+						},
+					},
+				},
+			},
+			"QuotedValue": {
+				expectedOutput: "# Managed env store retention strategy: last\n\n#\n# TEST_STRING_VALUE set in managed env store\n# \"export TEST_STRING_VALUE=\\\"value\\\"\"\n\n",
+				expectedResult: &ProgramResolverResult{
+					ModifiedProgram: true,
+					Variables: []ProgramResolverVarResult{
+						{
+							Status:        ProgramResolverStatusResolved,
+							Name:          "TEST_STRING_VALUE",
+							OriginalValue: "value",
+							Value:         "value",
+						},
+					},
+				},
+			},
+			"ParamExpr": {
+				expectedOutput: "# Managed env store retention strategy: last\n\nexport TEST_PARAM_EXPR=${TEST:7:0}\n",
+				expectedResult: &ProgramResolverResult{},
+			},
+		},
+	)
+
+	runTestCases(t, "PromptAll_LastRun",
+		ProgramResolverModePromptAll,
+		RetentionLastRun,
+		map[string]testOutput{
+			"NoValue": {
+				expectedOutput: "# Managed env store retention strategy: last\n\n#\n# TEST_NO_VALUE set in managed env store\n# \"export TEST_NO_VALUE\"\n\n",
+				expectedResult: &ProgramResolverResult{
+					ModifiedProgram: true,
+					Variables: []ProgramResolverVarResult{
+						{
+							Status: ProgramResolverStatusUnresolvedWithMessage,
+							Name:   "TEST_NO_VALUE",
+						},
+					},
+				},
+			},
+			"EmptyValue": {
+				expectedOutput: "# Managed env store retention strategy: last\n\n#\n# TEST_EMPTY_VALUE set in managed env store\n# \"export TEST_EMPTY_VALUE=\"\n\n",
+				expectedResult: &ProgramResolverResult{
+					ModifiedProgram: true,
+					Variables: []ProgramResolverVarResult{
+						{
+							Status: ProgramResolverStatusUnresolvedWithMessage,
+							Name:   "TEST_EMPTY_VALUE",
+						},
+					},
+				},
+			},
+			"NakedValue": {
+				expectedOutput: "# Managed env store retention strategy: last\n\n#\n# TEST_STRING_VALUE set in managed env store\n# \"export TEST_STRING_VALUE=value\"\n\n",
+				expectedResult: &ProgramResolverResult{
+					ModifiedProgram: true,
+					Variables: []ProgramResolverVarResult{
+						{
+							Status:        ProgramResolverStatusUnresolvedWithMessage,
+							Name:          "TEST_STRING_VALUE",
+							OriginalValue: "value",
+							Value:         "",
+						},
+					},
+				},
+			},
+			"QuotedValue": {
+				expectedOutput: "# Managed env store retention strategy: last\n\n#\n# TEST_STRING_VALUE set in managed env store\n# \"export TEST_STRING_VALUE=\\\"value\\\"\"\n\n",
+				expectedResult: &ProgramResolverResult{
+					ModifiedProgram: true,
+					Variables: []ProgramResolverVarResult{
+						{
+							Status:        ProgramResolverStatusUnresolvedWithPlaceholder,
+							Name:          "TEST_STRING_VALUE",
+							OriginalValue: "value",
+						},
+					},
+				},
+			},
+			"ParamExpr": {
+				expectedOutput: "# Managed env store retention strategy: last\n\nexport TEST_PARAM_EXPR=${TEST:7:0}\n",
+				expectedResult: &ProgramResolverResult{},
+			},
+		},
+	)
 }
 
 func TestProgramResolverResolve_ProgramResolverModeAuto(t *testing.T) {

--- a/internal/command/program_resolver_test.go
+++ b/internal/command/program_resolver_test.go
@@ -14,19 +14,30 @@ func TestProgramResolverResolve(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		program              string
-		result               *ProgramResolverResult
+		resultFirst          *ProgramResolverResult
+		resultLast           *ProgramResolverResult
 		modifiedProgramFirst string
 		modifiedProgramLast  string
 	}{
 		{
 			name:    "no value",
 			program: `export TEST_NO_VALUE`,
-			result: &ProgramResolverResult{
+			resultFirst: &ProgramResolverResult{
 				ModifiedProgram: true,
 				Variables: []ProgramResolverVarResult{
 					{
 						Status: ProgramResolverStatusUnresolved,
 						Name:   "TEST_NO_VALUE",
+					},
+				},
+			},
+			resultLast: &ProgramResolverResult{
+				ModifiedProgram: false,
+				Variables: []ProgramResolverVarResult{
+					{
+						Status: ProgramResolverStatusResolved,
+						Name:   "TEST_NO_VALUE",
+						Value:  "",
 					},
 				},
 			},
@@ -36,12 +47,22 @@ func TestProgramResolverResolve(t *testing.T) {
 		{
 			name:    "empty value",
 			program: `export TEST_EMPTY_VALUE=`,
-			result: &ProgramResolverResult{
+			resultFirst: &ProgramResolverResult{
 				ModifiedProgram: true,
 				Variables: []ProgramResolverVarResult{
 					{
 						Status: ProgramResolverStatusUnresolved,
 						Name:   "TEST_EMPTY_VALUE",
+					},
+				},
+			},
+			resultLast: &ProgramResolverResult{
+				ModifiedProgram: false,
+				Variables: []ProgramResolverVarResult{
+					{
+						Status: ProgramResolverStatusResolved,
+						Name:   "TEST_EMPTY_VALUE",
+						Value:  "",
 					},
 				},
 			},
@@ -51,7 +72,7 @@ func TestProgramResolverResolve(t *testing.T) {
 		{
 			name:    "string value",
 			program: `export TEST_STRING_VALUE=value`,
-			result: &ProgramResolverResult{
+			resultFirst: &ProgramResolverResult{
 				ModifiedProgram: true,
 				Variables: []ProgramResolverVarResult{
 					{
@@ -61,13 +82,24 @@ func TestProgramResolverResolve(t *testing.T) {
 					},
 				},
 			},
+			resultLast: &ProgramResolverResult{
+				ModifiedProgram: false,
+				Variables: []ProgramResolverVarResult{
+					{
+						Status:        ProgramResolverStatusResolved,
+						Name:          "TEST_STRING_VALUE",
+						OriginalValue: "value",
+						Value:         "value",
+					},
+				},
+			},
 			modifiedProgramFirst: "# Managed env store retention strategy: first\n\n#\n# TEST_STRING_VALUE set in managed env store\n# \"export TEST_STRING_VALUE=value\"\n\n",
 			modifiedProgramLast:  "# Managed env store retention strategy: last\n\nexport TEST_STRING_VALUE=value\n",
 		},
 		{
 			name:    "string value with equal sign",
 			program: `export TEST_STRING_VALUE_WITH_EQUAL_SIGN=part1=part2`,
-			result: &ProgramResolverResult{
+			resultFirst: &ProgramResolverResult{
 				ModifiedProgram: true,
 				Variables: []ProgramResolverVarResult{
 					{
@@ -77,18 +109,39 @@ func TestProgramResolverResolve(t *testing.T) {
 					},
 				},
 			},
+			resultLast: &ProgramResolverResult{
+				ModifiedProgram: false,
+				Variables: []ProgramResolverVarResult{
+					{
+						Status:        ProgramResolverStatusResolved,
+						Name:          "TEST_STRING_VALUE_WITH_EQUAL_SIGN",
+						OriginalValue: "part1=part2",
+						Value:         "part1=part2",
+					},
+				},
+			},
 			modifiedProgramFirst: "# Managed env store retention strategy: first\n\n#\n# TEST_STRING_VALUE_WITH_EQUAL_SIGN set in managed env store\n# \"export TEST_STRING_VALUE_WITH_EQUAL_SIGN=part1=part2\"\n\n",
 			modifiedProgramLast:  "# Managed env store retention strategy: last\n\nexport TEST_STRING_VALUE_WITH_EQUAL_SIGN=part1=part2\n",
 		},
 		{
 			name:    "string double quoted value empty",
 			program: `export TEST_STRING_DBL_QUOTED_VALUE_EMPTY=""`,
-			result: &ProgramResolverResult{
+			resultFirst: &ProgramResolverResult{
 				ModifiedProgram: true,
 				Variables: []ProgramResolverVarResult{
 					{
 						Status: ProgramResolverStatusUnresolved,
 						Name:   "TEST_STRING_DBL_QUOTED_VALUE_EMPTY",
+					},
+				},
+			},
+			resultLast: &ProgramResolverResult{
+				ModifiedProgram: false,
+				Variables: []ProgramResolverVarResult{
+					{
+						Status: ProgramResolverStatusResolved,
+						Name:   "TEST_STRING_DBL_QUOTED_VALUE_EMPTY",
+						Value:  "",
 					},
 				},
 			},
@@ -98,7 +151,7 @@ func TestProgramResolverResolve(t *testing.T) {
 		{
 			name:    "string double quoted value",
 			program: `export TEST_STRING_DBL_QUOTED_VALUE="value"`,
-			result: &ProgramResolverResult{
+			resultFirst: &ProgramResolverResult{
 				ModifiedProgram: true,
 				Variables: []ProgramResolverVarResult{
 					{
@@ -108,18 +161,39 @@ func TestProgramResolverResolve(t *testing.T) {
 					},
 				},
 			},
+			resultLast: &ProgramResolverResult{
+				ModifiedProgram: false,
+				Variables: []ProgramResolverVarResult{
+					{
+						Status:        ProgramResolverStatusResolved,
+						Name:          "TEST_STRING_DBL_QUOTED_VALUE",
+						OriginalValue: "value",
+						Value:         "value",
+					},
+				},
+			},
 			modifiedProgramFirst: "# Managed env store retention strategy: first\n\n#\n# TEST_STRING_DBL_QUOTED_VALUE set in managed env store\n# \"export TEST_STRING_DBL_QUOTED_VALUE=\\\"value\\\"\"\n\n",
 			modifiedProgramLast:  "# Managed env store retention strategy: last\n\nexport TEST_STRING_DBL_QUOTED_VALUE=\"value\"\n",
 		},
 		{
 			name:    "string single quoted value empty",
 			program: `export TEST_STRING_SGL_QUOTED_VALUE_EMPTY=''`,
-			result: &ProgramResolverResult{
+			resultFirst: &ProgramResolverResult{
 				ModifiedProgram: true,
 				Variables: []ProgramResolverVarResult{
 					{
 						Status: ProgramResolverStatusUnresolved,
 						Name:   "TEST_STRING_SGL_QUOTED_VALUE_EMPTY",
+					},
+				},
+			},
+			resultLast: &ProgramResolverResult{
+				ModifiedProgram: false,
+				Variables: []ProgramResolverVarResult{
+					{
+						Status: ProgramResolverStatusResolved,
+						Name:   "TEST_STRING_SGL_QUOTED_VALUE_EMPTY",
+						Value:  "",
 					},
 				},
 			},
@@ -129,7 +203,7 @@ func TestProgramResolverResolve(t *testing.T) {
 		{
 			name:    "string single quoted value",
 			program: `export TEST_STRING_SGL_QUOTED_VALUE='value'`,
-			result: &ProgramResolverResult{
+			resultFirst: &ProgramResolverResult{
 				ModifiedProgram: true,
 				Variables: []ProgramResolverVarResult{
 					{
@@ -139,13 +213,24 @@ func TestProgramResolverResolve(t *testing.T) {
 					},
 				},
 			},
+			resultLast: &ProgramResolverResult{
+				ModifiedProgram: false,
+				Variables: []ProgramResolverVarResult{
+					{
+						Status:        ProgramResolverStatusResolved,
+						Name:          "TEST_STRING_SGL_QUOTED_VALUE",
+						OriginalValue: "value",
+						Value:         "value",
+					},
+				},
+			},
 			modifiedProgramFirst: "# Managed env store retention strategy: first\n\n#\n# TEST_STRING_SGL_QUOTED_VALUE set in managed env store\n# \"export TEST_STRING_SGL_QUOTED_VALUE='value'\"\n\n",
 			modifiedProgramLast:  "# Managed env store retention strategy: last\n\nexport TEST_STRING_SGL_QUOTED_VALUE='value'\n",
 		},
 		{
 			name:    "shell-escaped prompt message",
 			program: `export TYPE=[Guest type \(hyperv,proxmox,openstack\)]`,
-			result: &ProgramResolverResult{
+			resultFirst: &ProgramResolverResult{
 				ModifiedProgram: true,
 				Variables: []ProgramResolverVarResult{
 					{
@@ -155,41 +240,57 @@ func TestProgramResolverResolve(t *testing.T) {
 					},
 				},
 			},
+			resultLast: &ProgramResolverResult{
+				ModifiedProgram: false,
+				Variables: []ProgramResolverVarResult{
+					{
+						Status:        ProgramResolverStatusResolved,
+						Name:          "TYPE",
+						OriginalValue: "[Guest type (hyperv,proxmox,openstack)]",
+						Value:         "[Guest type (hyperv,proxmox,openstack)]",
+					},
+				},
+			},
 			modifiedProgramFirst: "# Managed env store retention strategy: first\n\n#\n# TYPE set in managed env store\n# \"export TYPE=[Guest type \\\\(hyperv,proxmox,openstack\\\\)]\"\n\n",
 			modifiedProgramLast:  "# Managed env store retention strategy: last\n\nexport TYPE=[Guest type \\(hyperv,proxmox,openstack\\)]\n",
 		},
 		{
 			name:                 "parameter expression",
 			program:              `export TEST_PARAM_EXPR=${TEST:7:0}`,
-			result:               &ProgramResolverResult{},
+			resultFirst:          &ProgramResolverResult{},
+			resultLast:           &ProgramResolverResult{},
 			modifiedProgramFirst: "# Managed env store retention strategy: first\n\nexport TEST_PARAM_EXPR=${TEST:7:0}\n",
 			modifiedProgramLast:  "# Managed env store retention strategy: last\n\nexport TEST_PARAM_EXPR=${TEST:7:0}\n",
 		},
 		{
 			name:                 "arithmetic expression",
 			program:              `export TEST_ARITHM_EXPR=$(($z+3))`,
-			result:               &ProgramResolverResult{},
+			resultFirst:          &ProgramResolverResult{},
+			resultLast:           &ProgramResolverResult{},
 			modifiedProgramFirst: "# Managed env store retention strategy: first\n\nexport TEST_ARITHM_EXPR=$(($z + 3))\n",
 			modifiedProgramLast:  "# Managed env store retention strategy: last\n\nexport TEST_ARITHM_EXPR=$(($z + 3))\n",
 		},
 		{
 			name:                 "value expression",
 			program:              `export TEST_VALUE_EXPR=$(echo -n "value")`,
-			result:               &ProgramResolverResult{},
+			resultFirst:          &ProgramResolverResult{},
+			resultLast:           &ProgramResolverResult{},
 			modifiedProgramFirst: "# Managed env store retention strategy: first\n\nexport TEST_VALUE_EXPR=$(echo -n \"value\")\n",
 			modifiedProgramLast:  "# Managed env store retention strategy: last\n\nexport TEST_VALUE_EXPR=$(echo -n \"value\")\n",
 		},
 		{
 			name:                 "double quoted value expression",
 			program:              `export TEST_DBL_QUOTE_VALUE_EXPR="$(echo -n 'value')"`,
-			result:               &ProgramResolverResult{},
+			resultFirst:          &ProgramResolverResult{},
+			resultLast:           &ProgramResolverResult{},
 			modifiedProgramFirst: "# Managed env store retention strategy: first\n\nexport TEST_DBL_QUOTE_VALUE_EXPR=\"$(echo -n 'value')\"\n",
 			modifiedProgramLast:  "# Managed env store retention strategy: last\n\nexport TEST_DBL_QUOTE_VALUE_EXPR=\"$(echo -n 'value')\"\n",
 		},
 		{
 			name:                 "default value",
 			program:              `export TEST_DEFAULT_VALUE=${TEST_DEFAULT_VALUE:-value}`,
-			result:               &ProgramResolverResult{},
+			resultFirst:          &ProgramResolverResult{},
+			resultLast:           &ProgramResolverResult{},
 			modifiedProgramFirst: "# Managed env store retention strategy: first\n\nexport TEST_DEFAULT_VALUE=${TEST_DEFAULT_VALUE:-value}\n",
 			modifiedProgramLast:  "# Managed env store retention strategy: last\n\nexport TEST_DEFAULT_VALUE=${TEST_DEFAULT_VALUE:-value}\n",
 		},
@@ -206,13 +307,13 @@ func TestProgramResolverResolve(t *testing.T) {
 				name:            "First",
 				strategy:        RetentionFirstRun,
 				modifiedProgram: tc.modifiedProgramFirst,
-				result:          tc.result,
+				result:          tc.resultFirst,
 			},
 			{
 				name:            "Last",
 				strategy:        RetentionLastRun,
 				modifiedProgram: tc.modifiedProgramLast,
-				result:          nil, // for last strategy variables inside result are always empty
+				result:          tc.resultLast,
 			},
 		}
 

--- a/internal/command/program_resolver_test.go
+++ b/internal/command/program_resolver_test.go
@@ -167,55 +167,27 @@ func TestProgramResolverResolve(t *testing.T) {
 		RetentionLastRun,
 		map[string]testOutput{
 			"NoValue": {
-				expectedOutput: "# Managed env store retention strategy: last\n\n#\n# TEST_NO_VALUE set in managed env store\n# \"export TEST_NO_VALUE\"\n\n",
+				expectedOutput: "# Managed env store retention strategy: last\n\nexport TEST_NO_VALUE\n",
 				expectedResult: &ProgramResolverResult{
-					ModifiedProgram: true,
-					Variables: []ProgramResolverVarResult{
-						{
-							Status: ProgramResolverStatusResolved,
-							Name:   "TEST_NO_VALUE",
-						},
-					},
+					ModifiedProgram: false,
 				},
 			},
 			"EmptyValue": {
-				expectedOutput: "# Managed env store retention strategy: last\n\n#\n# TEST_EMPTY_VALUE set in managed env store\n# \"export TEST_EMPTY_VALUE=\"\n\n",
+				expectedOutput: "# Managed env store retention strategy: last\n\nexport TEST_EMPTY_VALUE=\n",
 				expectedResult: &ProgramResolverResult{
-					ModifiedProgram: true,
-					Variables: []ProgramResolverVarResult{
-						{
-							Status: ProgramResolverStatusResolved,
-							Name:   "TEST_EMPTY_VALUE",
-						},
-					},
+					ModifiedProgram: false,
 				},
 			},
 			"NakedValue": {
-				expectedOutput: "# Managed env store retention strategy: last\n\n#\n# TEST_STRING_VALUE set in managed env store\n# \"export TEST_STRING_VALUE=value\"\n\n",
+				expectedOutput: "# Managed env store retention strategy: last\n\nexport TEST_STRING_VALUE=value\n",
 				expectedResult: &ProgramResolverResult{
-					ModifiedProgram: true,
-					Variables: []ProgramResolverVarResult{
-						{
-							Status:        ProgramResolverStatusResolved,
-							Name:          "TEST_STRING_VALUE",
-							OriginalValue: "value",
-							Value:         "value",
-						},
-					},
+					ModifiedProgram: false,
 				},
 			},
 			"QuotedValue": {
-				expectedOutput: "# Managed env store retention strategy: last\n\n#\n# TEST_STRING_VALUE set in managed env store\n# \"export TEST_STRING_VALUE=\\\"value\\\"\"\n\n",
+				expectedOutput: "# Managed env store retention strategy: last\n\nexport TEST_STRING_VALUE=\"value\"\n",
 				expectedResult: &ProgramResolverResult{
-					ModifiedProgram: true,
-					Variables: []ProgramResolverVarResult{
-						{
-							Status:        ProgramResolverStatusResolved,
-							Name:          "TEST_STRING_VALUE",
-							OriginalValue: "value",
-							Value:         "value",
-						},
-					},
+					ModifiedProgram: false,
 				},
 			},
 			"ParamExpr": {
@@ -328,19 +300,11 @@ func TestProgramResolverResolve_ProgramResolverModeAuto_Last(t *testing.T) {
 	require.EqualValues(
 		t,
 		&ProgramResolverResult{
-			ModifiedProgram: true,
-			Variables: []ProgramResolverVarResult{
-				{
-					Status:        ProgramResolverStatusResolved,
-					Name:          "MY_ENV",
-					OriginalValue: "default",
-					Value:         "default",
-				},
-			},
+			ModifiedProgram: false,
 		},
 		result,
 	)
-	require.EqualValues(t, "# Managed env store retention strategy: last\n\n#\n# MY_ENV set in managed env store\n# \"export MY_ENV=default\"\n\n", buf.String())
+	require.EqualValues(t, "# Managed env store retention strategy: last\n\nexport MY_ENV=default\n", buf.String())
 }
 
 func TestProgramResolverResolve_ProgramResolverModePrompt(t *testing.T) {

--- a/internal/runner/service.go
+++ b/internal/runner/service.go
@@ -792,7 +792,7 @@ func (r *runnerService) getProgramResolverFromReq(req *runnerv1.ResolveProgramRe
 		}
 	}
 
-	mode := commandpkg.ProgramResolverModeAuto
+	mode := commandpkg.DefaultProgramResolverMode
 
 	switch req.GetMode() {
 	case runnerv1.ResolveProgramRequest_MODE_PROMPT_ALL:

--- a/internal/runner/service_test.go
+++ b/internal/runner/service_test.go
@@ -1074,27 +1074,29 @@ func Test_varRetentionStrategies(t *testing.T) {
 			retention:      runnerv1.ResolveProgramRequest_RETENTION_UNSPECIFIED,
 			resolvedVars:   3,
 			resolvedScript: "# Managed env store retention strategy: first\n\n#\n# VAR1 set in managed env store\n# \"export VAR1=\\\"bar\\\"\"\n\necho $VAR1 #\n# VAR2 set in managed env store\n# \"export VAR2=\\\"foo\\\"\"\n#\n# VAR2 set in managed env store\n# \"export VAR2=\\\"bar\\\"\"\n\necho $VAR2\n",
-			expectedStdout: "bar\nfoo\n",
-		},
-		{
-			name:           "Last",
-			retention:      runnerv1.ResolveProgramRequest_RETENTION_LAST_RUN,
-			resolvedVars:   0,
-			resolvedScript: "# Managed env store retention strategy: last\n\nexport VAR1=\"bar\"\necho $VAR1\nexport VAR2=\"foo\"\nexport VAR2=\"bar\"\necho $VAR2\n",
-			expectedStdout: "bar\nbar\n",
+			expectedStdout: "foo\nbar\n",
 		},
 		{
 			name:           "First",
 			resolvedVars:   3,
 			retention:      runnerv1.ResolveProgramRequest_RETENTION_FIRST_RUN,
 			resolvedScript: "# Managed env store retention strategy: first\n\n#\n# VAR1 set in managed env store\n# \"export VAR1=\\\"bar\\\"\"\n\necho $VAR1 #\n# VAR2 set in managed env store\n# \"export VAR2=\\\"foo\\\"\"\n#\n# VAR2 set in managed env store\n# \"export VAR2=\\\"bar\\\"\"\n\necho $VAR2\n",
-			expectedStdout: "bar\nfoo\n",
+			expectedStdout: "foo\nbar\n",
+		},
+		{
+			name:           "Last",
+			retention:      runnerv1.ResolveProgramRequest_RETENTION_LAST_RUN,
+			resolvedVars:   3,
+			resolvedScript: "# Managed env store retention strategy: last\n\n#\n# VAR1 set in managed env store\n# \"export VAR1=\\\"bar\\\"\"\n\necho $VAR1 #\n# VAR2 set in managed env store\n# \"export VAR2=\\\"foo\\\"\"\n#\n# VAR2 set in managed env store\n# \"export VAR2=\\\"bar\\\"\"\n\necho $VAR2\n",
+			expectedStdout: "bar\nbar\n",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run("Retention_"+tc.name, func(t *testing.T) {
-			s, err := client.CreateSession(context.Background(), &runnerv1.CreateSessionRequest{})
+			s, err := client.CreateSession(context.Background(), &runnerv1.CreateSessionRequest{
+				Envs: []string{"VAR1=foo"},
+			})
 			require.NoError(t, err)
 
 			sessionID := s.Session.Id
@@ -1129,9 +1131,14 @@ func Test_varRetentionStrategies(t *testing.T) {
 			assert.Len(t, resp.Vars, tc.resolvedVars)
 
 			// prepend the resolved vars
+			var resolvedVars string
 			for _, v := range resp.GetVars() {
-				script = "export " + v.GetName() + "=" + v.GetResolvedValue() + "\n" + script
+				if v.GetStatus() != runnerv1.ResolveProgramResponse_STATUS_RESOLVED {
+					continue
+				}
+				resolvedVars += "export " + v.GetName() + "=" + v.GetResolvedValue() + "\n"
 			}
+			script = resolvedVars + script
 
 			err = stream.Send(&runnerv1.ExecuteRequest{
 				ProgramName:     "bash",

--- a/internal/runner/service_test.go
+++ b/internal/runner/service_test.go
@@ -1086,8 +1086,8 @@ func Test_varRetentionStrategies(t *testing.T) {
 		{
 			name:           "Last",
 			retention:      runnerv1.ResolveProgramRequest_RETENTION_LAST_RUN,
-			resolvedVars:   3,
-			resolvedScript: "# Managed env store retention strategy: last\n\n#\n# VAR1 set in managed env store\n# \"export VAR1=\\\"bar\\\"\"\n\necho $VAR1 #\n# VAR2 set in managed env store\n# \"export VAR2=\\\"foo\\\"\"\n#\n# VAR2 set in managed env store\n# \"export VAR2=\\\"bar\\\"\"\n\necho $VAR2\n",
+			resolvedVars:   0,
+			resolvedScript: "# Managed env store retention strategy: last\n\nexport VAR1=\"bar\"\necho $VAR1\nexport VAR2=\"foo\"\nexport VAR2=\"bar\"\necho $VAR2\n",
 			expectedStdout: "bar\nbar\n",
 		},
 	}

--- a/internal/runnerv2service/service_execute_test.go
+++ b/internal/runnerv2service/service_execute_test.go
@@ -1202,27 +1202,29 @@ func Test_VarRetentionStrategies(t *testing.T) {
 			retention:      runnerv2.ResolveProgramRequest_RETENTION_UNSPECIFIED,
 			resolvedVars:   3,
 			resolvedScript: "# Managed env store retention strategy: first\n\n#\n# VAR1 set in managed env store\n# \"export VAR1=\\\"bar\\\"\"\n\necho $VAR1 #\n# VAR2 set in managed env store\n# \"export VAR2=\\\"foo\\\"\"\n#\n# VAR2 set in managed env store\n# \"export VAR2=\\\"bar\\\"\"\n\necho $VAR2\n",
-			expectedStdout: "bar\nfoo\n",
-		},
-		{
-			name:           "Last",
-			retention:      runnerv2.ResolveProgramRequest_RETENTION_LAST_RUN,
-			resolvedVars:   0,
-			resolvedScript: "# Managed env store retention strategy: last\n\nexport VAR1=\"bar\"\necho $VAR1\nexport VAR2=\"foo\"\nexport VAR2=\"bar\"\necho $VAR2\n",
-			expectedStdout: "bar\nbar\n",
+			expectedStdout: "foo\nbar\n",
 		},
 		{
 			name:           "First",
 			resolvedVars:   3,
 			retention:      runnerv2.ResolveProgramRequest_RETENTION_FIRST_RUN,
 			resolvedScript: "# Managed env store retention strategy: first\n\n#\n# VAR1 set in managed env store\n# \"export VAR1=\\\"bar\\\"\"\n\necho $VAR1 #\n# VAR2 set in managed env store\n# \"export VAR2=\\\"foo\\\"\"\n#\n# VAR2 set in managed env store\n# \"export VAR2=\\\"bar\\\"\"\n\necho $VAR2\n",
-			expectedStdout: "bar\nfoo\n",
+			expectedStdout: "foo\nbar\n",
+		},
+		{
+			name:           "Last",
+			retention:      runnerv2.ResolveProgramRequest_RETENTION_LAST_RUN,
+			resolvedVars:   3,
+			resolvedScript: "# Managed env store retention strategy: last\n\n#\n# VAR1 set in managed env store\n# \"export VAR1=\\\"bar\\\"\"\n\necho $VAR1 #\n# VAR2 set in managed env store\n# \"export VAR2=\\\"foo\\\"\"\n#\n# VAR2 set in managed env store\n# \"export VAR2=\\\"bar\\\"\"\n\necho $VAR2\n",
+			expectedStdout: "bar\nbar\n",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run("Retention_"+tc.name, func(t *testing.T) {
-			s, err := client.CreateSession(context.Background(), &runnerv2.CreateSessionRequest{})
+			s, err := client.CreateSession(context.Background(), &runnerv2.CreateSessionRequest{
+				Env: []string{"VAR1=foo"},
+			})
 			require.NoError(t, err)
 
 			sessionID := s.Session.Id
@@ -1257,9 +1259,14 @@ func Test_VarRetentionStrategies(t *testing.T) {
 			assert.Len(t, resp.Vars, tc.resolvedVars)
 
 			// prepend the resolved vars
+			var resolvedVars string
 			for _, v := range resp.GetVars() {
-				script = "export " + v.GetName() + "=" + v.GetResolvedValue() + "\n" + script
+				if v.GetStatus() != runnerv2.ResolveProgramResponse_STATUS_RESOLVED {
+					continue
+				}
+				resolvedVars += "export " + v.GetName() + "=" + v.GetResolvedValue() + "\n"
 			}
+			script = resolvedVars + script
 
 			err = stream.Send(&runnerv2.ExecuteRequest{
 				Config: &runnerv2.ProgramConfig{

--- a/internal/runnerv2service/service_execute_test.go
+++ b/internal/runnerv2service/service_execute_test.go
@@ -1214,8 +1214,8 @@ func Test_VarRetentionStrategies(t *testing.T) {
 		{
 			name:           "Last",
 			retention:      runnerv2.ResolveProgramRequest_RETENTION_LAST_RUN,
-			resolvedVars:   3,
-			resolvedScript: "# Managed env store retention strategy: last\n\n#\n# VAR1 set in managed env store\n# \"export VAR1=\\\"bar\\\"\"\n\necho $VAR1 #\n# VAR2 set in managed env store\n# \"export VAR2=\\\"foo\\\"\"\n#\n# VAR2 set in managed env store\n# \"export VAR2=\\\"bar\\\"\"\n\necho $VAR2\n",
+			resolvedVars:   0,
+			resolvedScript: "# Managed env store retention strategy: last\n\nexport VAR1=\"bar\"\necho $VAR1\nexport VAR2=\"foo\"\nexport VAR2=\"bar\"\necho $VAR2\n",
 			expectedStdout: "bar\nbar\n",
 		},
 	}


### PR DESCRIPTION
Bring back prompts, but only if cell attributes are set accordingly. Moreover, all values are placeholders, aka values in shell mode, with no prompt messages.