### PR TITLE
Make tag flag optionally works as a wildcard (default: `false`)

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"slices"
 	"strings"
 	"syscall"
 
@@ -40,6 +41,7 @@ func runCmd() *cobra.Command {
 		skipPrompts           bool
 		skipPromptsExplicitly bool
 		parallel              bool
+		tagMatchWildcard      bool
 		serverAddr            string
 		cmdCategories         []string
 		cmdTags               []string
@@ -108,13 +110,13 @@ func runCmd() *cobra.Command {
 							fm := block.Document().Frontmatter()
 							fmTags := resolveFrontmatterTags(fm)
 							match := false
-							if len(fmTags) > 0 && containsTags(fmTags, cmdTags) {
+							if len(fmTags) > 0 && matchesTags(fmTags, cmdTags, tagMatchWildcard) {
 								if len(blockTags) == 0 {
 									match = true
 								} else {
-									match = containsTags(fmTags, blockTags)
+									match = matchesTags(fmTags, blockTags, tagMatchWildcard)
 								}
-							} else if containsTags(blockTags, cmdTags) {
+							} else if matchesTags(blockTags, cmdTags, tagMatchWildcard) {
 								match = true
 							}
 
@@ -311,6 +313,7 @@ func runCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print the final command without executing.")
 	cmd.Flags().BoolVarP(&parallel, "parallel", "p", false, "Run tasks in parallel.")
 	cmd.Flags().BoolVarP(&runAll, "all", "a", false, "Run all commands.")
+	cmd.Flags().BoolVarP(&tagMatchWildcard, "wildcard", "e", false, "Match tags as wildcards.")
 	cmd.Flags().BoolVarP(&skipPrompts, "skip-prompts", "y", false, "Skip prompting for variables.")
 	cmd.Flags().StringArrayVarP(&cmdCategories, "category", "c", nil, "Run from a specific category.")
 	cmd.Flags().StringArrayVarP(&cmdTags, "tag", "t", nil, "Run from a specific tag.")
@@ -611,9 +614,21 @@ func resolveFrontmatterTags(fm *document.Frontmatter) []string {
 	return tags
 }
 
-func containsTags(s1 []string, s2 []string) bool {
-	for _, element := range s2 {
-		if strings.Contains(strings.Join(s1, ","), element) {
+func matchesTags(subject []string, candidates []string, contains bool) bool {
+	if contains {
+		// Join subject once and check if any candidate is contained in it
+		subjectStr := strings.Join(subject, ",")
+		for _, element := range candidates {
+			if strings.Contains(subjectStr, element) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Check if any candidate exists in the map
+	for _, element := range candidates {
+		if slices.Contains(subject, element) {
 			return true
 		}
 	}

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -41,7 +41,7 @@ func runCmd() *cobra.Command {
 		skipPrompts           bool
 		skipPromptsExplicitly bool
 		parallel              bool
-		tagMatchWildcard      bool
+		tagMatchPattern       bool
 		serverAddr            string
 		cmdCategories         []string
 		cmdTags               []string
@@ -110,13 +110,13 @@ func runCmd() *cobra.Command {
 							fm := block.Document().Frontmatter()
 							fmTags := resolveFrontmatterTags(fm)
 							match := false
-							if len(fmTags) > 0 && matchesTags(fmTags, cmdTags, tagMatchWildcard) {
+							if len(fmTags) > 0 && matchesTags(fmTags, cmdTags, tagMatchPattern) {
 								if len(blockTags) == 0 {
 									match = true
 								} else {
-									match = matchesTags(fmTags, blockTags, tagMatchWildcard)
+									match = matchesTags(fmTags, blockTags, tagMatchPattern)
 								}
-							} else if matchesTags(blockTags, cmdTags, tagMatchWildcard) {
+							} else if matchesTags(blockTags, cmdTags, tagMatchPattern) {
 								match = true
 							}
 
@@ -313,7 +313,7 @@ func runCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print the final command without executing.")
 	cmd.Flags().BoolVarP(&parallel, "parallel", "p", false, "Run tasks in parallel.")
 	cmd.Flags().BoolVarP(&runAll, "all", "a", false, "Run all commands.")
-	cmd.Flags().BoolVarP(&tagMatchWildcard, "wildcard", "e", false, "Match tags as wildcards.")
+	cmd.Flags().BoolVarP(&tagMatchPattern, "pattern", "e", false, "Match tags as pattern.")
 	cmd.Flags().BoolVarP(&skipPrompts, "skip-prompts", "y", false, "Skip prompting for variables.")
 	cmd.Flags().StringArrayVarP(&cmdCategories, "category", "c", nil, "Run from a specific category.")
 	cmd.Flags().StringArrayVarP(&cmdTags, "tag", "t", nil, "Run from a specific tag.")

--- a/testdata/tags/tags.txtar
+++ b/testdata/tags/tags.txtar
@@ -38,6 +38,15 @@ exec runme run --all --skip-prompts --tag solution-2
 cmp stdout doc-category.txt
 ! stderr .
 
+env SHELL=/bin/bash
+! exec runme run --all --skip-prompts --tag solution
+stderr 'could not execute command: No tasks to execute with the tag provided'
+
+env SHELL=/bin/bash
+exec runme run --all --skip-prompts -e --tag solution
+cmp stdout tag-pattern-matches.txt
+! stderr .
+
 -- TAGS.md --
 ```bash {"tag":"foo","name":"set-env"}
 $ export ENV="foo!"
@@ -179,3 +188,13 @@ Post-Deployment solution2
  ►  ✓ Task post-deployment-2 exited with code 0
 -- doc-category.txt --
 Post-Deployment solution2
+-- tag-pattern-matches.txt --
+ ►  Running task install-solution1...
+Install solution1
+ ►  ✓ Task install-solution1 exited with code 0
+ ►  Running task deploy-solution1...
+Deploy solution1
+ ►  ✓ Task deploy-solution1 exited with code 0
+ ►  Running task post-deployment-2...
+Post-Deployment solution2
+ ►  ✓ Task post-deployment-2 exited with code 0


### PR DESCRIPTION
The difference introduced in this PR is that the following command will only include cells with an exact match of `solution. '

```sh
runme run --all --skip-prompts --tag solution
```

Adding `--pattern` or the shorthand `-e` flag will match as substrings in tags, e.g. `solution-1` or `deploy-solution`.

```sh
runme run --all --skip-prompts -e --tag solution
```

Solves https://github.com/runmedev/runme/issues/775.