### PR TITLE
Make sure SHELL is always set

### DIFF
--- a/internal/runner/session_direnv.go
+++ b/internal/runner/session_direnv.go
@@ -39,7 +39,7 @@ func (s *Session) loadDirEnv(ctx context.Context, proj *project.Project) (string
 		Tty:     false,
 	}
 
-	const sourceDirEnv = "which direnv && eval $(direnv export $SHELL)"
+	const sourceDirEnv = "which direnv && SHELL=${SHELL:-$0} eval $(direnv export $SHELL)"
 	exec := &Shell{
 		ExecutableConfig: cfg,
 		Cmds:             []string{sourceDirEnv},


### PR DESCRIPTION
Not every Linux system has `SHELL` set by default. If it's not set, let's backfill it with the shell the program is running under, which is `$0`.