### PR TITLE
Fix 'go install' command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ npm install -g runme
 For users with different setups, you can visit [Runme's releases page](https://github.com/runmedev/runme/releases) and download a binary suitable for your operating system. For those with Go developer tools set up, Runme can be installed using the `go install` command:
 
 ```sh { name=install-via-go }
-$ go install github.com/runmedev/runme@latest
+$ go install github.com/runmedev/runme/v3@main
 
 ```
 


### PR DESCRIPTION
This PR fixes the Go installation command in the README, to resolve the following error:

```
$ go install github.com/runmedev/runme@latest
go: github.com/runmedev/runme@latest: version constraints conflict:
    github.com/runmedev/runme@v1.8.2: parsing go.mod:
    module declares its path as: github.com/stateful/runme
            but was required as: github.com/runmedev/runme
```