### PR TITLE
Timeout for multiplexers that remain inactivity

### DIFF
--- a/pkg/agent/runme/stream/connection.go
+++ b/pkg/agent/runme/stream/connection.go
@@ -46,8 +46,9 @@ func (sc *Connection) Error(message string) error {
 }
 
 // ErrorMessage sends an error to the websocket client before closing the connection.
-func (sc *Connection) ErrorMessage(ctx context.Context, code code.Code, message string) {
+func (sc *Connection) ErrorMessage(ctx context.Context, code code.Code, connErr error) {
 	log := logs.FromContextWithTrace(ctx)
+	message := connErr.Error()
 
 	response := &streamv1.WebsocketResponse{
 		Status: &streamv1.WebsocketStatus{

--- a/pkg/agent/runme/stream/handler_test.go
+++ b/pkg/agent/runme/stream/handler_test.go
@@ -48,6 +48,7 @@ func TestWebSocketHandler_Handler_SwitchingProtocols(t *testing.T) {
 		auth: &iam.AuthContext{
 			Checker: &iam.AllowAllChecker{},
 		},
+		runs: make(map[string]*Multiplexer),
 	}
 
 	ts := httptest.NewServer(http.HandlerFunc(h.Handler))

--- a/pkg/agent/runme/stream/handler_test.go
+++ b/pkg/agent/runme/stream/handler_test.go
@@ -190,6 +190,63 @@ func TestRunmeHandler_Roundtrip(t *testing.T) {
 	}
 }
 
+// Tests that the multiplexer closes after the inactivity timeout.
+func TestRunmeHandler_InactivityTimeout(t *testing.T) {
+	// Save and restore original timeout values for this test.
+	origClientGracePeriod := ClientGracePeriod
+	origMultiplexerTimeout := MultiplexerTimeout
+	origMultiplexerInterval := MultiplexerInterval
+	defer func() {
+		ClientGracePeriod = origClientGracePeriod
+		MultiplexerTimeout = origMultiplexerTimeout
+		MultiplexerInterval = origMultiplexerInterval
+	}()
+	// Set short timeouts for fast test execution.
+	ClientGracePeriod = 10 * time.Millisecond
+	MultiplexerTimeout = 100 * time.Millisecond
+	MultiplexerInterval = 10 * time.Millisecond
+
+	mockRunmeServer := newMockRunmeServer()
+	mockRunmeServer.SetResponder(func() error {
+		mockRunmeServer.executeResponses <- &v2.ExecuteResponse{
+			ExitCode: &wrappers.UInt32Value{Value: 1},
+		}
+		return nil
+	})
+
+	h := NewWebSocketHandler(
+		&runme.Runner{Server: mockRunmeServer},
+		&iam.AuthContext{Checker: &iam.AllowAllChecker{}},
+	)
+
+	ts := httptest.NewServer(http.HandlerFunc(h.Handler))
+	defer ts.Close()
+
+	runID := genULID()
+	sc, _, err := dialWebSocket(ts, runID.String())
+	if err != nil {
+		t.Errorf("Failed to dial websocket: %v", err)
+	}
+
+	time.Sleep(MultiplexerTimeout + MultiplexerInterval + ClientGracePeriod)
+
+	protoErr, err := sc.ReadWebsocketResponse(context.Background())
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if protoErr.GetStatus() == nil || protoErr.GetStatus().GetCode() != code.Code_DEADLINE_EXCEEDED {
+		t.Errorf("Expected status with code %q, got %v", code.Code_DEADLINE_EXCEEDED, protoErr.GetStatus())
+	}
+
+	_, err = sc.ReadWebsocketResponse(context.Background())
+	if err == nil {
+		t.Errorf("Expected websocket close error, got nil")
+	}
+	if wsErr, ok := err.(*websocket.CloseError); !ok || wsErr.Code != websocket.CloseProtocolError {
+		t.Errorf("Expected *websocket.CloseError with code 1002, got %T: %v", err, err)
+	}
+}
+
 // Tests websocket handler rejects requests with mismatched runIDs as unauthorized.
 func TestRunmeHandler_DenyMismatchedRunID(t *testing.T) {
 	mockRunmeServer := newMockRunmeServer()

--- a/pkg/agent/runme/stream/processor.go
+++ b/pkg/agent/runme/stream/processor.go
@@ -15,8 +15,10 @@ import (
 
 // Processor handles the v2.ExecuteRequest and v2.ExecuteResponse for a run in runme.Runner.
 type Processor struct {
-	Ctx              context.Context
-	RunID            string
+	Ctx   context.Context
+	RunID string
+	// ActiveRequests is used to signal to the multiplexer that the processor is actively executing requests.
+	ActiveRequests   bool
 	ExecuteRequests  chan *v2.ExecuteRequest
 	ExecuteResponses chan *v2.ExecuteResponse
 	// StopReading is used to signal to the readMessages goroutine that it should stop reading messages
@@ -65,6 +67,7 @@ func (p *Processor) Recv() (*v2.ExecuteRequest, error) {
 // error is returned if the stream was terminated unexpectedly, and the
 // handler method should return, as the stream is no longer usable.
 func (p *Processor) Send(res *v2.ExecuteResponse) error {
+	p.ActiveRequests = true
 	p.ExecuteResponses <- res
 	return nil
 }


### PR DESCRIPTION
Protect server from dangling multiplexers that never wind up processing requests.