### PR TITLE
Make extra handlers injectable.

### DIFF
--- a/pkg/agent/server/server.go
+++ b/pkg/agent/server/server.go
@@ -59,13 +59,14 @@ type Server struct {
 	registerHandlers RegisterHandlers
 }
 
-type RegisterHandlers func(mux *AuthMux, checker iam.Checker) error
+type RegisterHandlers func(mux *AuthMux, checker iam.Checker, interceptors []connect.Interceptor) error
 type Options struct {
 	Telemetry *config.TelemetryConfig
 	Server    *config.AssistantServerConfig
 	WebApp    *agentv1.WebAppConfig
 	IAMPolicy *api.IAMPolicy
-	// RegisterHandlers is a callback that allows you to register additional handlers in the server
+	// RegisterHandlers is a callback that allows you to register additional handlers in the server.
+	// These could be regular HTTP handlers or proto services.
 	RegisterHandlers RegisterHandlers
 }
 
@@ -317,7 +318,7 @@ func (s *Server) registerServices() error {
 
 	if s.registerHandlers != nil {
 		log.Info("Registering additional handlers")
-		if err := s.registerHandlers(mux, s.checker); err != nil {
+		if err := s.registerHandlers(mux, s.checker, interceptors); err != nil {
 			return err
 		}
 	}

--- a/pkg/agent/server/server.go
+++ b/pkg/agent/server/server.go
@@ -56,13 +56,17 @@ type Server struct {
 	parser           *runme.Parser
 	agent            agentv1connect.MessagesServiceHandler
 	checker          iam.Checker
+	registerHandlers RegisterHandlers
 }
 
+type RegisterHandlers func(mux *AuthMux, checker iam.Checker) error
 type Options struct {
 	Telemetry *config.TelemetryConfig
 	Server    *config.AssistantServerConfig
 	WebApp    *agentv1.WebAppConfig
 	IAMPolicy *api.IAMPolicy
+	// RegisterHandlers is a callback that allows you to register additional handlers in the server
+	RegisterHandlers RegisterHandlers
 }
 
 // NewServer creates a new server
@@ -128,13 +132,14 @@ func NewServer(opts Options, agent agentv1connect.MessagesServiceHandler) (*Serv
 	}
 
 	s := &Server{
-		telemetry:    opts.Telemetry,
-		serverConfig: opts.Server,
-		webAppConfig: opts.WebApp,
-		runner:       runner,
-		parser:       parser,
-		agent:        agent,
-		checker:      checker,
+		telemetry:        opts.Telemetry,
+		serverConfig:     opts.Server,
+		webAppConfig:     opts.WebApp,
+		runner:           runner,
+		parser:           parser,
+		agent:            agent,
+		checker:          checker,
+		registerHandlers: opts.RegisterHandlers,
 	}
 	return s, nil
 }
@@ -309,6 +314,13 @@ func (s *Server) registerServices() error {
 
 	mux.HandleFunc("/trailerstest", trailersTest)
 	mux.Handle("/metrics", promhttp.Handler())
+
+	if s.registerHandlers != nil {
+		log.Info("Registering additional handlers")
+		if err := s.registerHandlers(mux, s.checker); err != nil {
+			return err
+		}
+	}
 
 	// The single page app is currently only enabled in the agent not the runner.
 	if s.agent != nil {


### PR DESCRIPTION
* Add a function so that extra http or proto handlers can be added to the server
* Makes it easy for services to add additional services e.g. as backends for custom components

Related to #873 