### PR TITLE
fix(harbor): correlate Runme Codex sessions

### DIFF
--- a/integrations/harbor/src/runme_harbor/runme_agents.py
+++ b/integrations/harbor/src/runme_harbor/runme_agents.py
@@ -271,24 +271,101 @@ class RunmeCodex(Codex):
             return set()
         return {path for path in sessions_dir.rglob("*.jsonl") if path.is_file()}
 
-    def _collect_new_sessions(self, before: set[Path]) -> None:
+    def _codex_thread_id_from_output(self) -> str | None:
+        output_path = self.logs_dir / self._OUTPUT_FILENAME
+        if not output_path.exists():
+            return None
+
+        with open(output_path) as handle:
+            for line in handle:
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                if event.get("type") != "thread.started":
+                    continue
+
+                thread_id = event.get("thread_id")
+                if isinstance(thread_id, str) and thread_id:
+                    return thread_id
+
+        return None
+
+    @staticmethod
+    def _codex_session_ids_from_file(session_file: Path) -> set[str]:
+        with open(session_file) as handle:
+            for line in handle:
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                if event.get("type") != "session_meta":
+                    continue
+
+                payload = event.get("payload")
+                if not isinstance(payload, dict):
+                    return set()
+
+                session_ids: set[str] = set()
+                for key in ("id", "session_id"):
+                    session_id = payload.get(key)
+                    if isinstance(session_id, str) and session_id:
+                        session_ids.add(session_id)
+                return session_ids
+
+        return set()
+
+    def _select_new_session(self, new_sessions: set[Path]) -> Path | None:
+        if not new_sessions:
+            return None
+
+        thread_id = self._codex_thread_id_from_output()
+        if thread_id:
+            matches = [
+                session_file
+                for session_file in new_sessions
+                if thread_id in self._codex_session_ids_from_file(session_file)
+            ]
+            if len(matches) == 1:
+                return matches[0]
+            self.logger.warning(
+                "Could not uniquely match Codex thread %s to new session files: %s",
+                thread_id,
+                sorted(str(path) for path in new_sessions),
+            )
+            return None
+
+        if len(new_sessions) == 1:
+            return next(iter(new_sessions))
+
+        self.logger.warning(
+            "Could not identify Codex session file; multiple new sessions found: %s",
+            sorted(str(path) for path in new_sessions),
+        )
+        return None
+
+    def _collect_new_sessions(self, before: set[Path]) -> bool:
         sessions_dir = self._codex_sessions_dir()
         if not sessions_dir.exists():
-            return
+            return False
 
         after = {path for path in sessions_dir.rglob("*.jsonl") if path.is_file()}
         new_sessions = after - before
-        if not new_sessions:
-            return
 
         target_dir = self.logs_dir / "sessions"
         if target_dir.exists():
             shutil.rmtree(target_dir)
 
-        for session_file in new_sessions:
-            target = target_dir / session_file.relative_to(sessions_dir)
-            target.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(session_file, target)
+        session_file = self._select_new_session(new_sessions)
+        if session_file is None:
+            return False
+
+        target = target_dir / session_file.relative_to(sessions_dir)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(session_file, target)
+        return True
 
     @with_prompt_template
     async def run(
@@ -325,12 +402,14 @@ class RunmeCodex(Codex):
                 ),
             )
         finally:
+            collected_session = False
             try:
-                self._collect_new_sessions(session_files_before)
+                collected_session = self._collect_new_sessions(session_files_before)
             except Exception:
-                pass
+                self.logger.exception("Failed to collect Codex session file")
 
-            self.populate_context_post_run(context)
+            if collected_session:
+                self.populate_context_post_run(context)
 
 
 class RunmeCursorCli(CursorCli):

--- a/integrations/harbor/tests/test_runme_codex.py
+++ b/integrations/harbor/tests/test_runme_codex.py
@@ -75,3 +75,64 @@ def test_runme_codex_collects_only_new_sessions(
 
     assert not copied_old.exists()
     assert copied_new.read_text() == '{"type":"new"}\n'
+
+
+def test_runme_codex_collects_session_matching_thread_id(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    codex_home = tmp_path / "codex-home"
+    sessions_dir = codex_home / "sessions"
+    old_session = sessions_dir / "2026" / "08" / "05" / "old.jsonl"
+    session_a = sessions_dir / "2026" / "08" / "05" / "session-a.jsonl"
+    session_b = sessions_dir / "2026" / "08" / "05" / "session-b.jsonl"
+    old_session.parent.mkdir(parents=True)
+    old_session.write_text('{"type":"session_meta","payload":{"id":"old"}}\n')
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    agent = RunmeCodex(logs_dir=tmp_path / "logs")
+    before = agent._snapshot_session_files()
+    agent.logs_dir.mkdir(parents=True)
+    (agent.logs_dir / "codex.txt").write_text(
+        "Reading additional input from stdin...\n"
+        '{"type":"thread.started","thread_id":"session-b"}\n'
+    )
+
+    session_a.write_text('{"type":"session_meta","payload":{"id":"session-a"}}\n')
+    session_b.write_text(
+        '{"type":"session_meta","payload":{"session_id":"session-b"}}\n'
+    )
+
+    assert agent._collect_new_sessions(before)
+
+    copied_a = agent.logs_dir / "sessions" / session_a.relative_to(sessions_dir)
+    copied_b = agent.logs_dir / "sessions" / session_b.relative_to(sessions_dir)
+
+    assert not copied_a.exists()
+    assert copied_b.read_text() == (
+        '{"type":"session_meta","payload":{"session_id":"session-b"}}\n'
+    )
+
+
+def test_runme_codex_fails_closed_when_new_sessions_are_ambiguous(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    codex_home = tmp_path / "codex-home"
+    sessions_dir = codex_home / "sessions" / "2026" / "08" / "05"
+    session_a = sessions_dir / "session-a.jsonl"
+    session_b = sessions_dir / "session-b.jsonl"
+    sessions_dir.mkdir(parents=True)
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    agent = RunmeCodex(logs_dir=tmp_path / "logs")
+    before = agent._snapshot_session_files()
+    stale_session = agent.logs_dir / "sessions" / "stale.jsonl"
+    stale_session.parent.mkdir(parents=True)
+    stale_session.write_text('{"type":"stale"}\n')
+
+    session_a.write_text('{"type":"session_meta","payload":{"id":"session-a"}}\n')
+    session_b.write_text('{"type":"session_meta","payload":{"id":"session-b"}}\n')
+
+    assert not agent._collect_new_sessions(before)
+    assert not (agent.logs_dir / "sessions").exists()


### PR DESCRIPTION
## Summary

- correlate `RunmeCodex` session collection with the `thread.started.thread_id` emitted by `codex exec --json`
- copy only the matching ambient Codex session JSONL into Harbor logs before ATIF conversion
- fail closed on ambiguous new Codex sessions and skip conversion instead of handing Harbor multiple candidates

## Details

`RunmeCodex` intentionally runs against the user's ambient Codex home instead of setting `CODEX_HOME`. The previous collector snapshotted `~/.codex/sessions` before the run, then copied every new JSONL afterward. If another Codex process created a session during the same window, Harbor could receive multiple session files and convert the wrong one.

This keeps the unhermetic Runme behavior intact while adding correlation:

1. parse `thread.started.thread_id` from `agent/codex.txt`
2. inspect new candidate JSONLs for `session_meta.payload.id` or `session_meta.payload.session_id`
3. copy exactly one match into `agent/sessions`
4. skip `populate_context_post_run` when no unique match is available

## Tests

- `uv run --project integrations/harbor pytest integrations/harbor/tests/test_runme_codex.py -q`
- `runme run test`
