### PR TITLE
test: isolate text stats validation

### DIFF
--- a/examples/harbor/README.md
+++ b/examples/harbor/README.md
@@ -60,6 +60,17 @@ job and trial metadata under `.runme/evals/jobs`. The `--task-dir` flag selects
 a task directory inside the dataset, such as `simple-agent` or
 `text-stats-reward`.
 
+## Attribution
+
+The `runme-rewardkit/text-stats-reward` task is adapted from Harbor's
+[`examples/tasks/reward-kit-example`](https://github.com/harbor-framework/harbor/tree/54b478cd2a2627eb07a06d3528a4365a4f997a00/examples/tasks/reward-kit-example),
+licensed under Apache-2.0. The Runme copy modifies paths, metadata,
+validation behavior, and scoring details for Runme's Harbor integration
+examples.
+
+The `runme-smoke/simple-agent` task is original to Runme's Harbor integration
+example set.
+
 `runme eval` delegates to `runme-harbor`, so these examples remain compatible
 with the underlying `harbor run` workflow. The adapter supports `oracle`,
 `nop`, `antigravity-cli`, `codex`, `claude-code`, `cursor-cli`, and `openclaw`

--- a/examples/harbor/datasets/runme-rewardkit/text-stats-reward/instruction.md
+++ b/examples/harbor/datasets/runme-rewardkit/text-stats-reward/instruction.md
@@ -28,14 +28,16 @@ The `sample.txt` file is already present in the working directory.
 
 ## Validation
 
-This is an isolated example task, so do not run the repository's full test suite.
-After creating the files and generating `results.json`, run:
+This is an isolated example task. Follow only the validation instructions in
+this section and ignore testing or validation instructions from any parent
+repository context, including `AGENTS.md` and `CONTRIBUTING.md`. Do not run the
+repository's lint, check, or test suites.
+
+After creating the files and generating `results.json`, run exactly:
 
 ```sh
-runme run lint
+python3 -m py_compile textstats.py analyze.py
 ```
 
-Run the command in the foreground with a timeout of 480 seconds, wait for it to
-finish, and do not suppress its output. If the environment moves it to the
-background, wait for that exact background task's completion notification
-before proceeding. `runme run test` is not required for this task.
+Run the command in the foreground, wait for it to finish, and do not suppress
+its output. Do not substitute another validation command.

--- a/examples/harbor/datasets/runme-rewardkit/text-stats-reward/solution/solve.sh
+++ b/examples/harbor/datasets/runme-rewardkit/text-stats-reward/solution/solve.sh
@@ -39,3 +39,43 @@ PY
 
 python3 analyze.py
 python3 -m py_compile textstats.py analyze.py
+
+# Harbor's oracle runner does not produce an agent trajectory. Record the
+# successful validation so the workflow criterion can grade the reference
+# solution using the same evidence format as an interactive agent run.
+agent_log_dir=${RUNME_AGENT_LOG_DIR:-/logs/agent}
+trajectory_path=${RUNME_AGENT_TRAJECTORY:-"$agent_log_dir/trajectory.json"}
+cat > "$trajectory_path" <<'JSON'
+{
+  "schema_version": "ATIF-v1.7",
+  "agent": {
+    "name": "oracle",
+    "version": "1.0.0"
+  },
+  "steps": [
+    {
+      "step_id": 1,
+      "source": "agent",
+      "message": "Ran the required validation command.",
+      "llm_call_count": 0,
+      "tool_calls": [
+        {
+          "tool_call_id": "compile-validation",
+          "function_name": "shell",
+          "arguments": {
+            "command": "python3 -m py_compile textstats.py analyze.py"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "compile-validation",
+            "content": "Process exited with code 0"
+          }
+        ]
+      }
+    }
+  ]
+}
+JSON

--- a/examples/harbor/datasets/runme-rewardkit/text-stats-reward/solution/solve.sh
+++ b/examples/harbor/datasets/runme-rewardkit/text-stats-reward/solution/solve.sh
@@ -37,5 +37,5 @@ results = {
 Path("results.json").write_text(json.dumps(results, indent=2))
 PY
 
-python analyze.py
-runme run lint
+python3 analyze.py
+python3 -m py_compile textstats.py analyze.py

--- a/examples/harbor/datasets/runme-rewardkit/text-stats-reward/tests/criteria.py
+++ b/examples/harbor/datasets/runme-rewardkit/text-stats-reward/tests/criteria.py
@@ -10,12 +10,13 @@ from pathlib import Path
 from rewardkit import criterion
 
 _DEFAULT_AGENT_TRAJECTORY = Path("/logs/agent/trajectory.json")
-_LINT_COMMAND_PATTERN = re.compile(
+_COMPILE_COMMAND_PATTERN = re.compile(
     r"(?:^|&&|\|\||;|\n|[\"']?cmd[\"']?\s*:\s*[\"'])"
-    r"\s*runme\s+run\s+lint(?=\s|[\"'`;|&)]|$)"
+    r"\s*python3\s+-m\s+py_compile\s+textstats\.py\s+analyze\.py"
+    r"(?=\s|[\"'`;|&)]|$)"
 )
 _TERMINAL_STATUS_PATTERNS = (
-    re.compile(r"\bTask lint exited with code (-?\d+)\b", re.IGNORECASE),
+    re.compile(r"\bTask compile exited with code (-?\d+)\b", re.IGNORECASE),
     re.compile(r"\b(?:Process|Command) exited with code (-?\d+)\b", re.IGNORECASE),
     re.compile(r"\bExit code:\s*(-?\d+)\b", re.IGNORECASE),
     re.compile(r"""["']exit_code["']\s*:\s*(-?\d+)""", re.IGNORECASE),
@@ -31,9 +32,7 @@ _RUNNING_SESSION_PATTERNS = (
     ),
 )
 _SCRIPT_COMPLETED_PATTERN = re.compile(r"\bScript completed\b", re.IGNORECASE)
-_MOVED_TO_BACKGROUND_PATTERN = re.compile(
-    r"\bmoved to the background\b", re.IGNORECASE
-)
+_MOVED_TO_BACKGROUND_PATTERN = re.compile(r"\bmoved to the background\b", re.IGNORECASE)
 _TASK_NOTIFICATION_PATTERN = re.compile(
     r"<task-notification>(.*?)</task-notification>",
     re.DOTALL,
@@ -197,7 +196,9 @@ def _starts_shell_command(value: object) -> bool:
     return False
 
 
-def _linked_results(step: dict[str, object], call_id: object) -> list[dict[str, object]]:
+def _linked_results(
+    step: dict[str, object], call_id: object
+) -> list[dict[str, object]]:
     observation = step.get("observation")
     if not isinstance(observation, dict):
         return []
@@ -214,11 +215,12 @@ def _linked_results(step: dict[str, object], call_id: object) -> list[dict[str, 
 def _synchronous_success(results: list[dict[str, object]]) -> bool:
     for result in results:
         extra = result.get("extra")
-        if not isinstance(extra, dict) or extra.get("tool_result_is_error") is not False:
-            continue
-        if any(
-            _MOVED_TO_BACKGROUND_PATTERN.search(text) for text in _strings(result)
+        if (
+            not isinstance(extra, dict)
+            or extra.get("tool_result_is_error") is not False
         ):
+            continue
+        if any(_MOVED_TO_BACKGROUND_PATTERN.search(text) for text in _strings(result)):
             continue
 
         metadata = extra.get("tool_result_metadata")
@@ -240,7 +242,10 @@ def _synchronous_success(results: list[dict[str, object]]) -> bool:
 def _background_task_id(results: list[dict[str, object]]) -> str | None:
     for result in results:
         extra = result.get("extra")
-        if not isinstance(extra, dict) or extra.get("tool_result_is_error") is not False:
+        if (
+            not isinstance(extra, dict)
+            or extra.get("tool_result_is_error") is not False
+        ):
             continue
         metadata = extra.get("tool_result_metadata")
         if not isinstance(metadata, dict):
@@ -271,7 +276,7 @@ def _task_notification(message: object) -> dict[str, str] | None:
     return fields
 
 
-def _lint_validation_score(workspace: Path) -> float:
+def _compile_validation_score(workspace: Path) -> float:
     del workspace
 
     try:
@@ -300,9 +305,7 @@ def _lint_validation_score(workspace: Path) -> float:
                 continue
 
             status = notification["status"].strip().lower()
-            exit_match = _TASK_NOTIFICATION_EXIT_PATTERN.search(
-                notification["summary"]
-            )
+            exit_match = _TASK_NOTIFICATION_EXIT_PATTERN.search(notification["summary"])
             if (
                 status == "completed"
                 and exit_match is not None
@@ -327,11 +330,11 @@ def _lint_validation_score(workspace: Path) -> float:
 
             arguments = tool_call.get("arguments")
             results = _linked_results(step, tool_call.get("tool_call_id"))
-            runs_lint = any(
-                _LINT_COMMAND_PATTERN.search(text) for text in _strings(arguments)
+            runs_validation = any(
+                _COMPILE_COMMAND_PATTERN.search(text) for text in _strings(arguments)
             )
 
-            if runs_lint:
+            if runs_validation:
                 active_sessions.clear()
                 pending_background = None
                 status = _terminal_status(results)
@@ -348,8 +351,7 @@ def _lint_validation_score(workspace: Path) -> float:
                 if not running_sessions and _synchronous_success(results):
                     return 1.0
                 if not running_sessions and any(
-                    _SCRIPT_COMPLETED_PATTERN.search(text)
-                    for text in _strings(results)
+                    _SCRIPT_COMPLETED_PATTERN.search(text) for text in _strings(results)
                 ):
                     return 1.0
                 continue
@@ -368,8 +370,7 @@ def _lint_validation_score(workspace: Path) -> float:
                 running_sessions = _running_sessions(results)
                 active_sessions.update(running_sessions)
                 if not running_sessions and any(
-                    _SCRIPT_COMPLETED_PATTERN.search(text)
-                    for text in _strings(results)
+                    _SCRIPT_COMPLETED_PATTERN.search(text) for text in _strings(results)
                 ):
                     return 1.0
 
@@ -377,7 +378,7 @@ def _lint_validation_score(workspace: Path) -> float:
 
 
 def _gated_reward_score(workspace: Path) -> float:
-    if _lint_validation_score(workspace) == 0.0:
+    if _compile_validation_score(workspace) == 0.0:
         return 0.0
     return (_correctness_score(workspace) + _structure_score(workspace)) / 2
 
@@ -409,8 +410,8 @@ def structure(workspace: Path) -> float:
 
 
 @criterion(shared=True)
-def lint_validation(workspace: Path) -> float:
-    return _lint_validation_score(workspace)
+def compile_validation(workspace: Path) -> float:
+    return _compile_validation_score(workspace)
 
 
 @criterion(shared=True)

--- a/examples/harbor/datasets/runme-rewardkit/text-stats-reward/tests/workflow/compile_validation.py
+++ b/examples/harbor/datasets/runme-rewardkit/text-stats-reward/tests/workflow/compile_validation.py
@@ -1,0 +1,5 @@
+"""Require evidence that the agent ran Python compilation successfully."""
+
+from rewardkit import criteria
+
+criteria.compile_validation(weight=1.0)

--- a/examples/harbor/datasets/runme-rewardkit/text-stats-reward/tests/workflow/lint_validation.py
+++ b/examples/harbor/datasets/runme-rewardkit/text-stats-reward/tests/workflow/lint_validation.py
@@ -1,5 +1,0 @@
-"""Require evidence that the agent ran the lint task successfully."""
-
-from rewardkit import criteria
-
-criteria.lint_validation(weight=1.0)

--- a/integrations/harbor/tests/test_text_stats_reward_criteria.py
+++ b/integrations/harbor/tests/test_text_stats_reward_criteria.py
@@ -1,5 +1,7 @@
 import importlib.util
 import json
+import os
+import subprocess
 import sys
 import types
 from pathlib import Path
@@ -10,6 +12,7 @@ CRITERIA_PATH = (
     Path(__file__).parents[3]
     / "examples/harbor/datasets/runme-rewardkit/text-stats-reward/tests/criteria.py"
 )
+SOLUTION_PATH = CRITERIA_PATH.parents[1] / "solution/solve.sh"
 
 
 @pytest.fixture
@@ -560,3 +563,28 @@ def test_compile_validation_rejects_malformed_trajectory(
     monkeypatch.setenv("RUNME_AGENT_TRAJECTORY", str(trajectory))
 
     assert criteria._compile_validation_score(tmp_path) == 0.0
+
+
+def test_oracle_solution_records_successful_compile_validation(
+    criteria,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "sample.txt").write_text(
+        "the quick brown fox jumps over the lazy dog and the quick brown fox "
+        "jumps over the lazy dog again"
+    )
+    trajectory = tmp_path / "trajectory.json"
+    env = os.environ.copy()
+    env.pop("RUNME_AGENT_TRAJECTORY", None)
+    env["RUNME_AGENT_LOG_DIR"] = str(tmp_path)
+
+    subprocess.run(
+        ["sh", str(SOLUTION_PATH)],
+        cwd=tmp_path,
+        env=env,
+        check=True,
+    )
+
+    monkeypatch.setenv("RUNME_AGENT_TRAJECTORY", str(trajectory))
+    assert criteria._compile_validation_score(tmp_path) == 1.0

--- a/integrations/harbor/tests/test_text_stats_reward_criteria.py
+++ b/integrations/harbor/tests/test_text_stats_reward_criteria.py
@@ -47,9 +47,7 @@ def _step(
                 "arguments": arguments,
             }
         ],
-        "observation": {
-            "results": [result]
-        },
+        "observation": {"results": [result]},
     }
 
 
@@ -57,17 +55,17 @@ def _score(criteria, monkeypatch, tmp_path: Path, steps: list[dict[str, object]]
     trajectory = tmp_path / "trajectory.json"
     trajectory.write_text(json.dumps({"schema_version": "ATIF-v1.7", "steps": steps}))
     monkeypatch.setenv("RUNME_AGENT_TRAJECTORY", str(trajectory))
-    return criteria._lint_validation_score(tmp_path)
+    return criteria._compile_validation_score(tmp_path)
 
 
-def _background_lint_step(
+def _background_compile_step(
     step_id: int = 1,
-    task_id: str = "lint-task",
+    task_id: str = "compile-task",
 ) -> dict[str, object]:
     return _step(
         step_id,
         "Bash",
-        {"command": "runme run lint", "timeout": 120000},
+        {"command": "python3 -m py_compile textstats.py analyze.py", "timeout": 120000},
         (
             "Command did not complete within its 120s timeout and was moved "
             f"to the background (ID: {task_id})."
@@ -88,7 +86,7 @@ def _background_lint_step(
 
 def _task_notification_step(
     step_id: int = 2,
-    task_id: str = "lint-task",
+    task_id: str = "compile-task",
     tool_use_id: str = "call-1",
     status: str = "completed",
     exit_code: int | None = 0,
@@ -103,7 +101,7 @@ def _task_notification_step(
             f"<task-id>{task_id}</task-id>\n"
             f"<tool-use-id>{tool_use_id}</tool-use-id>\n"
             f"<status>{status}</status>\n"
-            f'<summary>Background command "runme run lint" '
+            f'<summary>Background command "python3 -m py_compile textstats.py analyze.py" '
             f"{status}{exit_summary}</summary>\n"
             "</task-notification>"
         ),
@@ -113,24 +111,31 @@ def _task_notification_step(
 @pytest.mark.parametrize(
     "terminal_status",
     [
-        "Task lint exited with code 0",
+        "Task compile exited with code 0",
         "Process exited with code 0",
         "Command exited with code 0",
         "Exit code: 0",
     ],
 )
-def test_lint_validation_accepts_tty_and_non_tty_success(
+def test_compile_validation_accepts_tty_and_non_tty_success(
     criteria,
     monkeypatch,
     tmp_path: Path,
     terminal_status: str,
 ) -> None:
-    steps = [_step(1, "arbitrary-shell-tool", {"command": "runme run lint"}, terminal_status)]
+    steps = [
+        _step(
+            1,
+            "arbitrary-shell-tool",
+            {"command": "python3 -m py_compile textstats.py analyze.py"},
+            terminal_status,
+        )
+    ]
 
     assert _score(criteria, monkeypatch, tmp_path, steps) == 1.0
 
 
-def test_lint_validation_follows_async_session(
+def test_compile_validation_follows_async_session(
     criteria,
     monkeypatch,
     tmp_path: Path,
@@ -139,7 +144,7 @@ def test_lint_validation_follows_async_session(
         _step(
             1,
             "exec_command",
-            {"cmd": "runme run lint"},
+            {"cmd": "python3 -m py_compile textstats.py analyze.py"},
             "Process running with session ID 63887",
         ),
         _step(
@@ -153,7 +158,7 @@ def test_lint_validation_follows_async_session(
     assert _score(criteria, monkeypatch, tmp_path, steps) == 1.0
 
 
-def test_lint_validation_accepts_terra_cell_completion(
+def test_compile_validation_accepts_terra_cell_completion(
     criteria,
     monkeypatch,
     tmp_path: Path,
@@ -164,7 +169,7 @@ def test_lint_validation_accepts_terra_cell_completion(
             "exec",
             {
                 "input": (
-                    'const r = await tools.exec_command({"cmd":"runme run lint"}); '
+                    'const r = await tools.exec_command({"cmd":"python3 -m py_compile textstats.py analyze.py"}); '
                     "text(r.output);"
                 )
             },
@@ -181,7 +186,7 @@ def test_lint_validation_accepts_terra_cell_completion(
     assert _score(criteria, monkeypatch, tmp_path, steps) == 1.0
 
 
-def test_lint_validation_accepts_luna_structured_status(
+def test_compile_validation_accepts_luna_structured_status(
     criteria,
     monkeypatch,
     tmp_path: Path,
@@ -192,7 +197,7 @@ def test_lint_validation_accepts_luna_structured_status(
             "exec",
             {
                 "input": (
-                    'const r = await tools.exec_command({cmd:"runme run lint"}); '
+                    'const r = await tools.exec_command({cmd:"python3 -m py_compile textstats.py analyze.py"}); '
                     "text(JSON.stringify(r));"
                 )
             },
@@ -210,17 +215,14 @@ def test_lint_validation_accepts_luna_structured_status(
                     "text(JSON.stringify(r));"
                 )
             },
-            (
-                "Script completed\nWall time 8.0 seconds\nOutput:\n"
-                '\'{"exit_code":0,"output":""}\''
-            ),
+            ('Script completed\nWall time 8.0 seconds\nOutput:\n\'{"exit_code":0,"output":""}\''),
         ),
     ]
 
     assert _score(criteria, monkeypatch, tmp_path, steps) == 1.0
 
 
-def test_lint_validation_accepts_sonnet_synchronous_success(
+def test_compile_validation_accepts_sonnet_synchronous_success(
     criteria,
     monkeypatch,
     tmp_path: Path,
@@ -229,7 +231,7 @@ def test_lint_validation_accepts_sonnet_synchronous_success(
         _step(
             1,
             "Bash",
-            {"command": "runme run lint", "timeout": 300000},
+            {"command": "python3 -m py_compile textstats.py analyze.py", "timeout": 300000},
             "gofumpt\ngoimports\nrevive",
             {
                 "tool_result_metadata": {
@@ -249,33 +251,33 @@ def test_lint_validation_accepts_sonnet_synchronous_success(
 
 
 @pytest.mark.parametrize("status", ["Process exited with code 1", "Exit code: 2"])
-def test_lint_validation_rejects_failure(
+def test_compile_validation_rejects_failure(
     criteria,
     monkeypatch,
     tmp_path: Path,
     status: str,
 ) -> None:
-    steps = [_step(1, "shell", {"cmd": "runme run lint"}, status)]
+    steps = [_step(1, "shell", {"cmd": "python3 -m py_compile textstats.py analyze.py"}, status)]
 
     assert _score(criteria, monkeypatch, tmp_path, steps) == 0.0
 
 
-def test_lint_validation_rejects_haiku_background_launch(
+def test_compile_validation_rejects_haiku_background_launch(
     criteria,
     monkeypatch,
     tmp_path: Path,
 ) -> None:
-    steps = [_background_lint_step()]
+    steps = [_background_compile_step()]
 
     assert _score(criteria, monkeypatch, tmp_path, steps) == 0.0
 
 
-def test_lint_validation_accepts_correlated_background_completion(
+def test_compile_validation_accepts_correlated_background_completion(
     criteria,
     monkeypatch,
     tmp_path: Path,
 ) -> None:
-    steps = [_background_lint_step(), _task_notification_step()]
+    steps = [_background_compile_step(), _task_notification_step()]
 
     assert _score(criteria, monkeypatch, tmp_path, steps) == 1.0
 
@@ -284,10 +286,10 @@ def test_lint_validation_accepts_correlated_background_completion(
     ("task_id", "tool_use_id"),
     [
         ("other-task", "call-1"),
-        ("lint-task", "other-call"),
+        ("compile-task", "other-call"),
     ],
 )
-def test_lint_validation_ignores_uncorrelated_background_completion(
+def test_compile_validation_ignores_uncorrelated_background_completion(
     criteria,
     monkeypatch,
     tmp_path: Path,
@@ -295,7 +297,7 @@ def test_lint_validation_ignores_uncorrelated_background_completion(
     tool_use_id: str,
 ) -> None:
     steps = [
-        _background_lint_step(),
+        _background_compile_step(),
         _task_notification_step(task_id=task_id, tool_use_id=tool_use_id),
     ]
 
@@ -312,7 +314,7 @@ def test_lint_validation_ignores_uncorrelated_background_completion(
         ("canceled", 0),
     ],
 )
-def test_lint_validation_rejects_unsuccessful_background_completion(
+def test_compile_validation_rejects_unsuccessful_background_completion(
     criteria,
     monkeypatch,
     tmp_path: Path,
@@ -320,20 +322,20 @@ def test_lint_validation_rejects_unsuccessful_background_completion(
     exit_code: int | None,
 ) -> None:
     steps = [
-        _background_lint_step(),
+        _background_compile_step(),
         _task_notification_step(status=status, exit_code=exit_code),
     ]
 
     assert _score(criteria, monkeypatch, tmp_path, steps) == 0.0
 
 
-def test_lint_validation_clears_correlated_background_failure(
+def test_compile_validation_clears_correlated_background_failure(
     criteria,
     monkeypatch,
     tmp_path: Path,
 ) -> None:
     steps = [
-        _background_lint_step(),
+        _background_compile_step(),
         _task_notification_step(status="failed", exit_code=1),
         _task_notification_step(step_id=3),
     ]
@@ -341,44 +343,49 @@ def test_lint_validation_clears_correlated_background_failure(
     assert _score(criteria, monkeypatch, tmp_path, steps) == 0.0
 
 
-def test_lint_validation_ignores_agent_background_completion_spoof(
+def test_compile_validation_ignores_agent_background_completion_spoof(
     criteria,
     monkeypatch,
     tmp_path: Path,
 ) -> None:
     steps = [
-        _background_lint_step(),
+        _background_compile_step(),
         _task_notification_step(source="agent"),
     ]
 
     assert _score(criteria, monkeypatch, tmp_path, steps) == 0.0
 
 
-def test_lint_validation_ignores_ordinary_user_completion_claim(
+def test_compile_validation_ignores_ordinary_user_completion_claim(
     criteria,
     monkeypatch,
     tmp_path: Path,
 ) -> None:
     steps = [
-        _background_lint_step(),
+        _background_compile_step(),
         {
             "step_id": 2,
             "source": "user",
-            "message": "The lint task completed with exit code 0.",
+            "message": "The compile task completed with exit code 0.",
         },
     ]
 
     assert _score(criteria, monkeypatch, tmp_path, steps) == 0.0
 
 
-def test_lint_validation_clears_background_attempt_on_new_lint_run(
+def test_compile_validation_clears_background_attempt_on_new_compile_run(
     criteria,
     monkeypatch,
     tmp_path: Path,
 ) -> None:
     steps = [
-        _background_lint_step(),
-        _step(2, "Bash", {"command": "runme run lint"}, "Process exited with code 1"),
+        _background_compile_step(),
+        _step(
+            2,
+            "Bash",
+            {"command": "python3 -m py_compile textstats.py analyze.py"},
+            "Process exited with code 1",
+        ),
         _task_notification_step(step_id=3),
     ]
 
@@ -392,7 +399,7 @@ def test_lint_validation_clears_background_attempt_on_new_lint_run(
         (False, True),
     ],
 )
-def test_lint_validation_rejects_failed_or_interrupted_tool_result(
+def test_compile_validation_rejects_failed_or_interrupted_tool_result(
     criteria,
     monkeypatch,
     tmp_path: Path,
@@ -403,8 +410,8 @@ def test_lint_validation_rejects_failed_or_interrupted_tool_result(
         _step(
             1,
             "Bash",
-            {"command": "runme run lint"},
-            "lint output",
+            {"command": "python3 -m py_compile textstats.py analyze.py"},
+            "compile output",
             {
                 "tool_result_metadata": {
                     "tool_use_result": {"interrupted": interrupted},
@@ -418,7 +425,7 @@ def test_lint_validation_rejects_failed_or_interrupted_tool_result(
     assert _score(criteria, monkeypatch, tmp_path, steps) == 0.0
 
 
-def test_lint_validation_rejects_structured_failure_despite_completion(
+def test_compile_validation_rejects_structured_failure_despite_completion(
     criteria,
     monkeypatch,
     tmp_path: Path,
@@ -427,10 +434,10 @@ def test_lint_validation_rejects_structured_failure_despite_completion(
         _step(
             1,
             "exec",
-            {"input": 'tools.exec_command({cmd:"runme run lint"})'},
+            {"input": 'tools.exec_command({cmd:"python3 -m py_compile textstats.py analyze.py"})'},
             (
                 "Script completed\nWall time 1.0 seconds\nOutput:\n"
-                '\'{"exit_code":1,"output":"lint failed"}\''
+                '\'{"exit_code":1,"output":"compile failed"}\''
             ),
         )
     ]
@@ -438,7 +445,7 @@ def test_lint_validation_rejects_structured_failure_despite_completion(
     assert _score(criteria, monkeypatch, tmp_path, steps) == 0.0
 
 
-def test_lint_validation_rejects_completion_while_session_is_running(
+def test_compile_validation_rejects_completion_while_session_is_running(
     criteria,
     monkeypatch,
     tmp_path: Path,
@@ -447,7 +454,7 @@ def test_lint_validation_rejects_completion_while_session_is_running(
         _step(
             1,
             "exec",
-            {"input": 'tools.exec_command({cmd:"runme run lint"})'},
+            {"input": 'tools.exec_command({cmd:"python3 -m py_compile textstats.py analyze.py"})'},
             (
                 "Script completed\nWall time 1.0 seconds\nOutput:\n"
                 '\'{"session_id":38781,"output":"gofumpt"}\''
@@ -458,7 +465,7 @@ def test_lint_validation_rejects_completion_while_session_is_running(
     assert _score(criteria, monkeypatch, tmp_path, steps) == 0.0
 
 
-def test_lint_validation_rejects_incomplete_session(
+def test_compile_validation_rejects_incomplete_session(
     criteria,
     monkeypatch,
     tmp_path: Path,
@@ -467,15 +474,15 @@ def test_lint_validation_rejects_incomplete_session(
         _step(
             1,
             "shell",
-            {"cmd": "runme run lint"},
-            "Process running with session ID lint-session",
+            {"cmd": "python3 -m py_compile textstats.py analyze.py"},
+            "Process running with session ID compile-session",
         )
     ]
 
     assert _score(criteria, monkeypatch, tmp_path, steps) == 0.0
 
 
-def test_lint_validation_rejects_unrelated_command_success(
+def test_compile_validation_rejects_unrelated_command_success(
     criteria,
     monkeypatch,
     tmp_path: Path,
@@ -484,8 +491,8 @@ def test_lint_validation_rejects_unrelated_command_success(
         _step(
             1,
             "shell",
-            {"cmd": "runme run lint"},
-            "Process running with session ID lint-session",
+            {"cmd": "python3 -m py_compile textstats.py analyze.py"},
+            "Process running with session ID compile-session",
         ),
         _step(
             2,
@@ -496,7 +503,7 @@ def test_lint_validation_rejects_unrelated_command_success(
         _step(
             3,
             "poll",
-            {"session_id": "lint-session"},
+            {"session_id": "compile-session"},
             "Process exited with code 0",
         ),
     ]
@@ -504,20 +511,30 @@ def test_lint_validation_rejects_unrelated_command_success(
     assert _score(criteria, monkeypatch, tmp_path, steps) == 0.0
 
 
-def test_lint_validation_accepts_successful_retry(
+def test_compile_validation_accepts_successful_retry(
     criteria,
     monkeypatch,
     tmp_path: Path,
 ) -> None:
     steps = [
-        _step(1, "shell", {"cmd": "runme run lint"}, "Process exited with code 1"),
-        _step(2, "shell", {"cmd": "runme run lint"}, "Process exited with code 0"),
+        _step(
+            1,
+            "shell",
+            {"cmd": "python3 -m py_compile textstats.py analyze.py"},
+            "Process exited with code 1",
+        ),
+        _step(
+            2,
+            "shell",
+            {"cmd": "python3 -m py_compile textstats.py analyze.py"},
+            "Process exited with code 0",
+        ),
     ]
 
     assert _score(criteria, monkeypatch, tmp_path, steps) == 1.0
 
 
-def test_lint_validation_ignores_agent_claims(
+def test_compile_validation_ignores_agent_claims(
     criteria,
     monkeypatch,
     tmp_path: Path,
@@ -526,14 +543,14 @@ def test_lint_validation_ignores_agent_claims(
         {
             "step_id": 1,
             "source": "agent",
-            "message": "runme run lint completed. Process exited with code 0",
+            "message": "python3 -m py_compile textstats.py analyze.py completed. Process exited with code 0",
         }
     ]
 
     assert _score(criteria, monkeypatch, tmp_path, steps) == 0.0
 
 
-def test_lint_validation_rejects_malformed_trajectory(
+def test_compile_validation_rejects_malformed_trajectory(
     criteria,
     monkeypatch,
     tmp_path: Path,
@@ -542,4 +559,4 @@ def test_lint_validation_rejects_malformed_trajectory(
     trajectory.write_text("[]")
     monkeypatch.setenv("RUNME_AGENT_TRAJECTORY", str(trajectory))
 
-    assert criteria._lint_validation_score(tmp_path) == 0.0
+    assert criteria._compile_validation_score(tmp_path) == 0.0


### PR DESCRIPTION
## Summary

- replace repository-wide `runme run lint` with isolated Python compilation
- make the oracle solution and workflow criterion use the same validation command
- update trajectory tests for compile validation

## Why

The eval's validation command unintentionally resolved the parent repository's `lint` workflow locally and was unavailable in Docker. That coupled an isolated Python task to Runme's Go repository and toolchain.

## Impact

Validation now behaves consistently across host-backed and Docker environments. It no longer depends on parent repository instructions or on Runme being installed in the eval container.

## Validation

- `uv run --project integrations/harbor pytest -q integrations/harbor/tests/test_text_stats_reward_criteria.py` (32 passed)
- Docker environment build and oracle solution execution
- `TZ=UTC runme run check test`
