### PR TITLE
fix(harbor): merge scoped env during exec

### DIFF
--- a/integrations/harbor/src/runme_harbor/environment.py
+++ b/integrations/harbor/src/runme_harbor/environment.py
@@ -216,11 +216,12 @@ class RunmeEnvironment(BaseEnvironment):
         timeout_sec: int | None = None,
         user: str | int | None = None,
     ) -> ExecResult:
+        merged_env = self._merge_env(env)
         request = {
             "exec": {
                 "command": self._rewrite_command(command),
                 "cwd": self._map_protocol_path(cwd or self.task_env_config.workdir or "/app"),
-                "env": _env_map_to_list(env or {}),
+                "env": _env_map_to_list(merged_env or {}),
             }
         }
         try:

--- a/integrations/harbor/tests/test_environment.py
+++ b/integrations/harbor/tests/test_environment.py
@@ -111,6 +111,52 @@ def test_environment_starts_runme_harbor_stdio(
     }
 
 
+def test_exec_merges_persistent_per_call_and_scoped_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    FakeClient.instances.clear()
+    monkeypatch.setattr(env_module, "_StdioClient", FakeClient)
+
+    environment = _make_env(
+        tmp_path,
+        persistent_env={
+            "PERSISTENT_ENV": "yes",
+            "SHARED": "persistent",
+        },
+    )
+
+    asyncio.run(environment.start(force_build=False))
+    token = environment._exec_env_overlays.set(
+        (
+            {
+                "SCOPED_ENV": "yes",
+                "SHARED": "scoped",
+            },
+        )
+    )
+    try:
+        asyncio.run(
+            environment.exec(
+                "env",
+                env={
+                    "PER_EXEC_ENV": "yes",
+                    "SHARED": "per-exec",
+                },
+            )
+        )
+    finally:
+        environment._exec_env_overlays.reset(token)
+
+    request_env = FakeClient.instances[0].requests[-1]["exec"]["env"]
+    assert "PERSISTENT_ENV=yes" in request_env
+    assert "PER_EXEC_ENV=yes" in request_env
+    assert "SCOPED_ENV=yes" in request_env
+    assert "SHARED=scoped" in request_env
+    assert "SHARED=per-exec" not in request_env
+    assert "SHARED=persistent" not in request_env
+
+
 def test_stdio_client_allows_large_protojson_lines(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, Any] = {}
 


### PR DESCRIPTION
## Summary

- merge Harbor persistent/per-exec/scoped env in `RunmeEnvironment.exec()`
- preserve start-time and Go-side env behavior
- add regression coverage for scoped agent env precedence

## Test

- `cd integrations/harbor && uv run pytest tests/test_environment.py`
- `cd integrations/harbor && uv run pytest`
- `runme run test`
