### PR TITLE
fix(harbor): route agent auth through managed fallbacks

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -14,21 +14,23 @@ import (
 )
 
 type evalOptions struct {
-	agent           string
-	taskDir         string
-	jobsDir         string
-	ask             bool
-	agentKwargs     []string
-	agentEnv        []string
-	model           string
-	env             string
-	runmeBin        string
-	runmeArgs       []string
-	runmeHarbor     string
-	debug           bool
-	jobsDirExplicit bool
-	stdout          io.Writer
-	stderr          io.Writer
+	agent              string
+	taskDir            string
+	jobsDir            string
+	ask                bool
+	agentKwargs        []string
+	agentEnv           []string
+	verifierEnv        []string
+	verifierEnvDefault []string
+	model              string
+	env                string
+	runmeBin           string
+	runmeArgs          []string
+	runmeHarbor        string
+	debug              bool
+	jobsDirExplicit    bool
+	stdout             io.Writer
+	stderr             io.Writer
 }
 
 type evalRunner interface {
@@ -110,6 +112,8 @@ func newEvalRunCmd(use, short, long string) *cobra.Command {
 	flags.BoolVar(&opts.ask, "ask", false, "Do not auto-accept Harbor confirmation prompts")
 	flags.StringArrayVar(&opts.agentKwargs, "agent-kwarg", nil, "Harbor agent kwarg; can be repeated; alias: --ak")
 	flags.StringArrayVar(&opts.agentEnv, "agent-env", nil, "Environment variable to pass to the agent in KEY=VALUE format; can be repeated; alias: --ae")
+	flags.StringArrayVar(&opts.verifierEnv, "verifier-env", nil, "Environment variable to pass to the verifier in KEY=VALUE format; can be repeated")
+	flags.StringArrayVar(&opts.verifierEnvDefault, "verifier-env-default", nil, "Fallback environment variable for the verifier in KEY=VALUE format; can be repeated")
 	flags.StringVar(&opts.model, "model", "", "Harbor agent model")
 	flags.StringVarP(&opts.env, "env", "e", "", `Harbor environment to use. Defaults to "runme"`)
 	flags.StringVar(&opts.runmeBin, "runme-bin", "", "Runme binary used by the Harbor environment")
@@ -122,22 +126,24 @@ func newEvalRunCmd(use, short, long string) *cobra.Command {
 
 func runEval(opts evalOptions, args []string) error {
 	err := newEvalRunner(harbor.EvalOptions{
-		Agent:           opts.agent,
-		TaskDir:         opts.taskDir,
-		JobsDir:         opts.jobsDir,
-		Ask:             opts.ask,
-		AgentKwargs:     opts.agentKwargs,
-		AgentEnv:        opts.agentEnv,
-		Model:           opts.model,
-		Env:             opts.env,
-		RunmeBin:        opts.runmeBin,
-		RunmeArgs:       opts.runmeArgs,
-		RunmeHarborBin:  opts.runmeHarbor,
-		Debug:           opts.debug,
-		JobsDirExplicit: opts.jobsDirExplicit,
-		Stdout:          opts.stdout,
-		Stderr:          opts.stderr,
-		Preflight:       true,
+		Agent:              opts.agent,
+		TaskDir:            opts.taskDir,
+		JobsDir:            opts.jobsDir,
+		Ask:                opts.ask,
+		AgentKwargs:        opts.agentKwargs,
+		AgentEnv:           opts.agentEnv,
+		VerifierEnv:        opts.verifierEnv,
+		VerifierEnvDefault: opts.verifierEnvDefault,
+		Model:              opts.model,
+		Env:                opts.env,
+		RunmeBin:           opts.runmeBin,
+		RunmeArgs:          opts.runmeArgs,
+		RunmeHarborBin:     opts.runmeHarbor,
+		Debug:              opts.debug,
+		JobsDirExplicit:    opts.jobsDirExplicit,
+		Stdout:             opts.stdout,
+		Stderr:             opts.stderr,
+		Preflight:          true,
 	}).Run(args)
 	if err == nil {
 		return nil

--- a/integrations/harbor/src/runme_harbor/runme_agents.py
+++ b/integrations/harbor/src/runme_harbor/runme_agents.py
@@ -5,7 +5,7 @@ import shutil
 import tempfile
 from hashlib import sha256
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from harbor.agents.installed.antigravity_cli import AntigravityCli
 from harbor.agents.installed.base import CliFlag, with_prompt_template
@@ -20,6 +20,14 @@ from harbor.models.trial.paths import EnvironmentPaths
 
 _OPENAI_FALLBACK_ENV = "RUNME_ROUTER_FALLBACK_OPENAI_API_KEY"
 _ANTHROPIC_FALLBACK_ENV = "RUNME_ROUTER_FALLBACK_ANTHROPIC_API_KEY"
+
+_ProviderAuthSource = Literal[
+    "explicit",
+    "native",
+    "fallback",
+    "indeterminate",
+    "unconfigured",
+]
 
 
 async def _command_succeeds(
@@ -59,17 +67,21 @@ async def _promote_fallback_auth(
     provider_key: str,
     fallback_key: str,
     native_auth_probe,
-) -> None:
+) -> _ProviderAuthSource:
     if source._has_env(provider_key):
-        return
+        return "explicit"
 
     fallback = source._get_env(fallback_key)
     if not fallback:
-        return
+        return "unconfigured"
 
     native_auth = await native_auth_probe(environment, env)
     if native_auth is False:
         env[provider_key] = fallback
+        return "fallback"
+    if native_auth is True:
+        return "native"
+    return "indeterminate"
 
 
 class RunmeAntigravityCli(AntigravityCli):
@@ -457,8 +469,15 @@ class RunmeCodex(Codex):
         )
 
     async def _agent_env(self, environment: BaseEnvironment) -> dict[str, str]:
+        env, _ = await self._agent_env_and_router_state(environment)
+        return env
+
+    async def _agent_env_and_router_state(
+        self,
+        environment: BaseEnvironment,
+    ) -> tuple[dict[str, str], bool]:
         env: dict[str, str] = {}
-        await _promote_fallback_auth(
+        auth_source = await _promote_fallback_auth(
             self,
             environment,
             env,
@@ -466,7 +485,11 @@ class RunmeCodex(Codex):
             _OPENAI_FALLBACK_ENV,
             self._has_native_auth,
         )
-        return env
+        route_through_configured_base_url = auth_source not in {
+            "native",
+            "indeterminate",
+        }
+        return env, route_through_configured_base_url
 
     def _openai_base_url_arg(self) -> str:
         base_url = self._get_env("OPENAI_BASE_URL")
@@ -487,9 +510,15 @@ class RunmeCodex(Codex):
 
         cli_flags = self.build_cli_flags()
         cli_flags_arg = f"{cli_flags} " if cli_flags else ""
-        base_url_arg = self._openai_base_url_arg()
         session_files_before = self._snapshot_session_files()
-        env = await self._agent_env(environment)
+        env, route_through_configured_base_url = (
+            await self._agent_env_and_router_state(environment)
+        )
+        base_url_arg = (
+            self._openai_base_url_arg()
+            if route_through_configured_base_url
+            else ""
+        )
 
         try:
             await self.exec_as_agent(

--- a/integrations/harbor/src/runme_harbor/runme_agents.py
+++ b/integrations/harbor/src/runme_harbor/runme_agents.py
@@ -20,6 +20,7 @@ from harbor.models.trial.paths import EnvironmentPaths
 
 _OPENAI_FALLBACK_ENV = "RUNME_ROUTER_FALLBACK_OPENAI_API_KEY"
 _ANTHROPIC_FALLBACK_ENV = "RUNME_ROUTER_FALLBACK_ANTHROPIC_API_KEY"
+_GOOGLE_FALLBACK_ENV = "RUNME_ROUTER_FALLBACK_GOOGLE_API_KEY"
 _CODEX_ROUTER_PROVIDER = "runme_router"
 
 _ProviderAuthSource = Literal[
@@ -61,6 +62,18 @@ def _copy_if_present(
         env[key] = value
 
 
+def _parse_bool_kwarg(name: str, value: bool | str) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized == "true":
+            return True
+        if normalized == "false":
+            return False
+    raise ValueError(f"{name} must be true or false")
+
+
 async def _promote_fallback_auth(
     source,
     environment: BaseEnvironment,
@@ -70,9 +83,13 @@ async def _promote_fallback_auth(
     native_auth_probe,
     *,
     native_auth_first: bool = False,
+    detect_native_auth: bool = False,
 ) -> _ProviderAuthSource:
     fallback = source._get_env(fallback_key)
-    if native_auth_first and fallback:
+    if source._has_env(provider_key) and not (native_auth_first and fallback):
+        return "explicit"
+
+    if fallback or detect_native_auth:
         native_auth = await native_auth_probe(environment, env)
         if native_auth is True:
             env.pop(provider_key, None)
@@ -86,15 +103,6 @@ async def _promote_fallback_auth(
 
     if not fallback:
         return "unconfigured"
-
-    if not native_auth_first:
-        native_auth = await native_auth_probe(environment, env)
-        if native_auth is True:
-            env.pop(provider_key, None)
-            return "native"
-        if native_auth is None:
-            env.pop(provider_key, None)
-            return "indeterminate"
 
     env[provider_key] = fallback
     return "fallback"
@@ -112,6 +120,12 @@ class RunmeAntigravityCli(AntigravityCli):
     @staticmethod
     def name() -> str:
         return "runme-antigravity-cli"
+
+    def __init__(self, *args, route_oauth_credentials: bool | str = False, **kwargs):
+        self.route_oauth_credentials = _parse_bool_kwarg(
+            "route_oauth_credentials", route_oauth_credentials
+        )
+        super().__init__(*args, **kwargs)
 
     async def install(self, environment: BaseEnvironment) -> None:
         return None
@@ -149,6 +163,14 @@ class RunmeAntigravityCli(AntigravityCli):
         ]
         for var in auth_vars:
             _copy_if_present(self, env, var)
+
+        has_explicit_key = self._has_env("GEMINI_API_KEY") or self._has_env("GOOGLE_API_KEY")
+        fallback = self._get_env(_GOOGLE_FALLBACK_ENV)
+        if not has_explicit_key and fallback:
+            env["GEMINI_API_KEY"] = fallback
+        elif not has_explicit_key and not self.route_oauth_credentials:
+            env.pop("GOOGLE_GEMINI_BASE_URL", None)
+            env.pop("GOOGLE_VERTEX_BASE_URL", None)
 
         skills_command = self._build_register_skills_command()
         if skills_command:
@@ -216,6 +238,12 @@ class RunmeClaudeCode(ClaudeCode):
     def name() -> str:
         return "runme-claude-code"
 
+    def __init__(self, *args, route_oauth_credentials: bool | str = False, **kwargs):
+        self.route_oauth_credentials = _parse_bool_kwarg(
+            "route_oauth_credentials", route_oauth_credentials
+        )
+        super().__init__(*args, **kwargs)
+
     async def install(self, environment: BaseEnvironment) -> None:
         return None
 
@@ -254,10 +282,12 @@ class RunmeClaudeCode(ClaudeCode):
             target.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(session_file, target)
 
-    def _model_arg(self) -> str:
+    def _model_arg(self, route_via_router: bool | None = None) -> str:
         if not self.model_name:
             return ""
-        if self._get_env("ANTHROPIC_BASE_URL"):
+        if route_via_router is None:
+            route_via_router = bool(self._get_env("ANTHROPIC_BASE_URL"))
+        if route_via_router:
             model = self.model_name
         elif self._is_bedrock_mode() and "/" in self.model_name:
             model = self.model_name.split("/", 1)[-1]
@@ -272,7 +302,8 @@ class RunmeClaudeCode(ClaudeCode):
     ) -> bool | None:
         return await _command_succeeds(
             environment,
-            'unset ANTHROPIC_API_KEY; export PATH="$HOME/.local/bin:$PATH"; '
+            "unset ANTHROPIC_API_KEY ANTHROPIC_BASE_URL; "
+            'export PATH="$HOME/.local/bin:$PATH"; '
             "claude auth status",
             env=env,
         )
@@ -311,7 +342,10 @@ class RunmeClaudeCode(ClaudeCode):
             _ANTHROPIC_FALLBACK_ENV,
             self._has_native_auth,
             native_auth_first=True,
+            detect_native_auth=bool(self._get_env("ANTHROPIC_BASE_URL")),
         )
+        if auth_source in {"native", "indeterminate"} and not self.route_oauth_credentials:
+            env.pop("ANTHROPIC_BASE_URL", None)
         return env, auth_source
 
     @with_prompt_template
@@ -322,16 +356,14 @@ class RunmeClaudeCode(ClaudeCode):
         context: AgentContext,
     ) -> None:
         escaped_instruction = shlex.quote(instruction)
-        model_arg = self._model_arg()
         cli_flags = self.build_cli_flags()
         cli_flags_arg = f"{cli_flags} " if cli_flags else ""
         session_files_before = self._snapshot_session_files()
         env, auth_source = await self._agent_env_and_auth_source(environment)
         native_auth_arg = (
-            "unset ANTHROPIC_API_KEY\n"
-            if auth_source in {"native", "indeterminate"}
-            else ""
+            "unset ANTHROPIC_API_KEY\n" if auth_source in {"native", "indeterminate"} else ""
         )
+        model_arg = self._model_arg(bool(env.get("ANTHROPIC_BASE_URL")))
 
         try:
             await self.exec_as_agent(
@@ -371,6 +403,12 @@ class RunmeCodex(Codex):
     @staticmethod
     def name() -> str:
         return "runme-codex"
+
+    def __init__(self, *args, route_oauth_credentials: bool | str = False, **kwargs):
+        self.route_oauth_credentials = _parse_bool_kwarg(
+            "route_oauth_credentials", route_oauth_credentials
+        )
+        super().__init__(*args, **kwargs)
 
     async def install(self, environment: BaseEnvironment) -> None:
         return None
@@ -517,6 +555,7 @@ class RunmeCodex(Codex):
             _OPENAI_FALLBACK_ENV,
             self._has_native_auth,
             native_auth_first=True,
+            detect_native_auth=bool(self._get_env("OPENAI_BASE_URL")),
         )
         return env, auth_source
 
@@ -558,7 +597,11 @@ class RunmeCodex(Codex):
         env, auth_source = await self._agent_env_and_router_state(environment)
         native_auth = auth_source in {"native", "indeterminate"}
         provider_args = (
-            self._native_router_args() if native_auth else self._router_provider_args()
+            self._native_router_args()
+            if native_auth and self.route_oauth_credentials
+            else self._router_provider_args()
+            if not native_auth
+            else ""
         )
         native_auth_arg = "unset OPENAI_API_KEY OPENAI_BASE_URL\n" if native_auth else ""
 

--- a/integrations/harbor/src/runme_harbor/runme_agents.py
+++ b/integrations/harbor/src/runme_harbor/runme_agents.py
@@ -20,6 +20,7 @@ from harbor.models.trial.paths import EnvironmentPaths
 
 _OPENAI_FALLBACK_ENV = "RUNME_ROUTER_FALLBACK_OPENAI_API_KEY"
 _ANTHROPIC_FALLBACK_ENV = "RUNME_ROUTER_FALLBACK_ANTHROPIC_API_KEY"
+_CODEX_ROUTER_PROVIDER = "runme_router"
 
 _ProviderAuthSource = Literal[
     "explicit",
@@ -505,11 +506,20 @@ class RunmeCodex(Codex):
         }
         return env, route_through_configured_base_url
 
-    def _openai_base_url_arg(self) -> str:
+    def _router_provider_args(self) -> str:
         base_url = self._get_env("OPENAI_BASE_URL")
         if not base_url:
             return ""
-        return f"-c {_config_arg('openai_base_url', base_url)} "
+        provider = f"model_providers.{_CODEX_ROUTER_PROVIDER}"
+        settings = (
+            ("model_provider", _CODEX_ROUTER_PROVIDER),
+            (f"{provider}.name", "Runme Router"),
+            (f"{provider}.base_url", base_url),
+            (f"{provider}.env_key", "OPENAI_API_KEY"),
+            (f"{provider}.wire_api", "responses"),
+        )
+        args = "".join(f"-c {_config_arg(key, value)} " for key, value in settings)
+        return f"{args}-c {provider}.supports_websockets=false "
 
     @with_prompt_template
     async def run(
@@ -526,7 +536,7 @@ class RunmeCodex(Codex):
         cli_flags_arg = f"{cli_flags} " if cli_flags else ""
         session_files_before = self._snapshot_session_files()
         env, route_through_configured_base_url = await self._agent_env_and_router_state(environment)
-        base_url_arg = self._openai_base_url_arg() if route_through_configured_base_url else ""
+        provider_args = self._router_provider_args() if route_through_configured_base_url else ""
         native_auth_arg = (
             "unset OPENAI_API_KEY OPENAI_BASE_URL\n"
             if not route_through_configured_base_url
@@ -543,7 +553,7 @@ class RunmeCodex(Codex):
                     "codex exec "
                     "--dangerously-bypass-approvals-and-sandbox "
                     "--skip-git-repo-check "
-                    f"{base_url_arg}"
+                    f"{provider_args}"
                     f"{model_arg}"
                     "--json "
                     "--enable unified_exec "

--- a/integrations/harbor/src/runme_harbor/runme_agents.py
+++ b/integrations/harbor/src/runme_harbor/runme_agents.py
@@ -299,6 +299,7 @@ class RunmeClaudeCode(ClaudeCode):
             "ANTHROPIC_API_KEY",
             _ANTHROPIC_FALLBACK_ENV,
             self._has_native_auth,
+            native_auth_first=True,
         )
         return env
 
@@ -489,7 +490,7 @@ class RunmeCodex(Codex):
     async def _agent_env_and_router_state(
         self,
         environment: BaseEnvironment,
-    ) -> tuple[dict[str, str], bool]:
+    ) -> tuple[dict[str, str], _ProviderAuthSource]:
         env: dict[str, str] = {}
         auth_source = await _promote_fallback_auth(
             self,
@@ -500,11 +501,7 @@ class RunmeCodex(Codex):
             self._has_native_auth,
             native_auth_first=True,
         )
-        route_through_configured_base_url = auth_source not in {
-            "native",
-            "indeterminate",
-        }
-        return env, route_through_configured_base_url
+        return env, auth_source
 
     def _router_provider_args(self) -> str:
         base_url = self._get_env("OPENAI_BASE_URL")
@@ -521,6 +518,12 @@ class RunmeCodex(Codex):
         args = "".join(f"-c {_config_arg(key, value)} " for key, value in settings)
         return f"{args}-c {provider}.supports_websockets=false "
 
+    def _native_router_args(self) -> str:
+        base_url = self._get_env("OPENAI_BASE_URL")
+        if not base_url:
+            return ""
+        return f"-c {_config_arg('openai_base_url', base_url)} "
+
     @with_prompt_template
     async def run(
         self,
@@ -535,13 +538,12 @@ class RunmeCodex(Codex):
         cli_flags = self.build_cli_flags()
         cli_flags_arg = f"{cli_flags} " if cli_flags else ""
         session_files_before = self._snapshot_session_files()
-        env, route_through_configured_base_url = await self._agent_env_and_router_state(environment)
-        provider_args = self._router_provider_args() if route_through_configured_base_url else ""
-        native_auth_arg = (
-            "unset OPENAI_API_KEY OPENAI_BASE_URL\n"
-            if not route_through_configured_base_url
-            else ""
+        env, auth_source = await self._agent_env_and_router_state(environment)
+        native_auth = auth_source in {"native", "indeterminate"}
+        provider_args = (
+            self._native_router_args() if native_auth else self._router_provider_args()
         )
+        native_auth_arg = "unset OPENAI_API_KEY OPENAI_BASE_URL\n" if native_auth else ""
 
         try:
             await self.exec_as_agent(

--- a/integrations/harbor/src/runme_harbor/runme_agents.py
+++ b/integrations/harbor/src/runme_harbor/runme_agents.py
@@ -67,21 +67,32 @@ async def _promote_fallback_auth(
     provider_key: str,
     fallback_key: str,
     native_auth_probe,
+    *,
+    native_auth_first: bool = False,
 ) -> _ProviderAuthSource:
+    fallback = source._get_env(fallback_key)
+    if native_auth_first and fallback:
+        native_auth = await native_auth_probe(environment, env)
+        if native_auth is True:
+            return "native"
+        if native_auth is None:
+            return "indeterminate"
+
     if source._has_env(provider_key):
         return "explicit"
 
-    fallback = source._get_env(fallback_key)
     if not fallback:
         return "unconfigured"
 
-    native_auth = await native_auth_probe(environment, env)
-    if native_auth is False:
-        env[provider_key] = fallback
-        return "fallback"
-    if native_auth is True:
-        return "native"
-    return "indeterminate"
+    if not native_auth_first:
+        native_auth = await native_auth_probe(environment, env)
+        if native_auth is True:
+            return "native"
+        if native_auth is None:
+            return "indeterminate"
+
+    env[provider_key] = fallback
+    return "fallback"
 
 
 class RunmeAntigravityCli(AntigravityCli):
@@ -464,7 +475,9 @@ class RunmeCodex(Codex):
     ) -> bool | None:
         return await _command_succeeds(
             environment,
-            "if [ -s ~/.nvm/nvm.sh ]; then . ~/.nvm/nvm.sh; fi; codex login status",
+            "unset OPENAI_API_KEY OPENAI_BASE_URL; "
+            "if [ -s ~/.nvm/nvm.sh ]; then . ~/.nvm/nvm.sh; fi; "
+            "codex login status",
             env=env,
         )
 
@@ -484,6 +497,7 @@ class RunmeCodex(Codex):
             "OPENAI_API_KEY",
             _OPENAI_FALLBACK_ENV,
             self._has_native_auth,
+            native_auth_first=True,
         )
         route_through_configured_base_url = auth_source not in {
             "native",
@@ -511,12 +525,11 @@ class RunmeCodex(Codex):
         cli_flags = self.build_cli_flags()
         cli_flags_arg = f"{cli_flags} " if cli_flags else ""
         session_files_before = self._snapshot_session_files()
-        env, route_through_configured_base_url = (
-            await self._agent_env_and_router_state(environment)
-        )
-        base_url_arg = (
-            self._openai_base_url_arg()
-            if route_through_configured_base_url
+        env, route_through_configured_base_url = await self._agent_env_and_router_state(environment)
+        base_url_arg = self._openai_base_url_arg() if route_through_configured_base_url else ""
+        native_auth_arg = (
+            "unset OPENAI_API_KEY OPENAI_BASE_URL\n"
+            if not route_through_configured_base_url
             else ""
         )
 
@@ -525,6 +538,7 @@ class RunmeCodex(Codex):
                 environment,
                 command=(
                     "set -o pipefail\n"
+                    f"{native_auth_arg}"
                     "if [ -s ~/.nvm/nvm.sh ]; then . ~/.nvm/nvm.sh; fi\n"
                     "codex exec "
                     "--dangerously-bypass-approvals-and-sandbox "

--- a/integrations/harbor/src/runme_harbor/runme_agents.py
+++ b/integrations/harbor/src/runme_harbor/runme_agents.py
@@ -78,6 +78,7 @@ async def _promote_fallback_auth(
             env.pop(provider_key, None)
             return "native"
         if native_auth is None:
+            env.pop(provider_key, None)
             return "indeterminate"
 
     if source._has_env(provider_key):
@@ -92,6 +93,7 @@ async def _promote_fallback_auth(
             env.pop(provider_key, None)
             return "native"
         if native_auth is None:
+            env.pop(provider_key, None)
             return "indeterminate"
 
     env[provider_key] = fallback
@@ -293,9 +295,15 @@ class RunmeClaudeCode(ClaudeCode):
         return env
 
     async def _agent_env(self, environment: BaseEnvironment) -> dict[str, str]:
+        env, _ = await self._agent_env_and_auth_source(environment)
+        return env
+
+    async def _agent_env_and_auth_source(
+        self, environment: BaseEnvironment
+    ) -> tuple[dict[str, str], _ProviderAuthSource]:
         env = self._runtime_env()
         _copy_if_present(self, env, "ANTHROPIC_BASE_URL")
-        await _promote_fallback_auth(
+        auth_source = await _promote_fallback_auth(
             self,
             environment,
             env,
@@ -304,7 +312,7 @@ class RunmeClaudeCode(ClaudeCode):
             self._has_native_auth,
             native_auth_first=True,
         )
-        return env
+        return env, auth_source
 
     @with_prompt_template
     async def run(
@@ -318,13 +326,19 @@ class RunmeClaudeCode(ClaudeCode):
         cli_flags = self.build_cli_flags()
         cli_flags_arg = f"{cli_flags} " if cli_flags else ""
         session_files_before = self._snapshot_session_files()
-        env = await self._agent_env(environment)
+        env, auth_source = await self._agent_env_and_auth_source(environment)
+        native_auth_arg = (
+            "unset ANTHROPIC_API_KEY\n"
+            if auth_source in {"native", "indeterminate"}
+            else ""
+        )
 
         try:
             await self.exec_as_agent(
                 environment,
                 command=(
                     "set -o pipefail\n"
+                    f"{native_auth_arg}"
                     "claude --verbose --output-format=stream-json "
                     "--permission-mode=bypassPermissions "
                     f"{model_arg}"

--- a/integrations/harbor/src/runme_harbor/runme_agents.py
+++ b/integrations/harbor/src/runme_harbor/runme_agents.py
@@ -18,6 +18,59 @@ from harbor.models.agent.context import AgentContext
 from harbor.models.trajectories.trajectory import Trajectory
 from harbor.models.trial.paths import EnvironmentPaths
 
+_OPENAI_FALLBACK_ENV = "RUNME_ROUTER_FALLBACK_OPENAI_API_KEY"
+_ANTHROPIC_FALLBACK_ENV = "RUNME_ROUTER_FALLBACK_ANTHROPIC_API_KEY"
+
+
+async def _command_succeeds(
+    environment: BaseEnvironment,
+    command: str,
+    env: dict[str, str] | None = None,
+) -> bool | None:
+    try:
+        result = await environment.exec(command=command, env=env)
+    except Exception:
+        return None
+    return result.return_code == 0
+
+
+def _toml_string(value: str) -> str:
+    return json.dumps(value)
+
+
+def _config_arg(key: str, value: str) -> str:
+    return shlex.quote(f"{key}={_toml_string(value)}")
+
+
+def _copy_if_present(
+    source,
+    env: dict[str, str],
+    key: str,
+) -> None:
+    value = source._get_env(key)
+    if value:
+        env[key] = value
+
+
+async def _promote_fallback_auth(
+    source,
+    environment: BaseEnvironment,
+    env: dict[str, str],
+    provider_key: str,
+    fallback_key: str,
+    native_auth_probe,
+) -> None:
+    if source._has_env(provider_key):
+        return
+
+    fallback = source._get_env(fallback_key)
+    if not fallback:
+        return
+
+    native_auth = await native_auth_probe(environment, env)
+    if native_auth is False:
+        env[provider_key] = fallback
+
 
 class RunmeAntigravityCli(AntigravityCli):
     """Antigravity CLI-backed Runme agent without container bootstrap.
@@ -61,12 +114,13 @@ class RunmeAntigravityCli(AntigravityCli):
             "GOOGLE_APPLICATION_CREDENTIALS",
             "GOOGLE_CLOUD_PROJECT",
             "GOOGLE_CLOUD_LOCATION",
+            "GOOGLE_GEMINI_BASE_URL",
             "GOOGLE_GENAI_USE_VERTEXAI",
+            "GOOGLE_VERTEX_BASE_URL",
             "GOOGLE_API_KEY",
         ]
         for var in auth_vars:
-            if var in os.environ:
-                env[var] = os.environ[var]
+            _copy_if_present(self, env, var)
 
         skills_command = self._build_register_skills_command()
         if skills_command:
@@ -175,13 +229,24 @@ class RunmeClaudeCode(ClaudeCode):
     def _model_arg(self) -> str:
         if not self.model_name:
             return ""
-        if os.environ.get("ANTHROPIC_BASE_URL"):
+        if self._get_env("ANTHROPIC_BASE_URL"):
             model = self.model_name
         elif self._is_bedrock_mode() and "/" in self.model_name:
             model = self.model_name.split("/", 1)[-1]
         else:
             model = self.model_name.split("/")[-1]
         return f"--model {shlex.quote(model)} "
+
+    async def _has_native_auth(
+        self,
+        environment: BaseEnvironment,
+        env: dict[str, str],
+    ) -> bool | None:
+        return await _command_succeeds(
+            environment,
+            'export PATH="$HOME/.local/bin:$PATH"; claude auth status',
+            env=env,
+        )
 
     def _runtime_env(self) -> dict[str, str]:
         env = {
@@ -200,6 +265,19 @@ class RunmeClaudeCode(ClaudeCode):
         env.update(self._resolved_env_vars)
         return env
 
+    async def _agent_env(self, environment: BaseEnvironment) -> dict[str, str]:
+        env = self._runtime_env()
+        _copy_if_present(self, env, "ANTHROPIC_BASE_URL")
+        await _promote_fallback_auth(
+            self,
+            environment,
+            env,
+            "ANTHROPIC_API_KEY",
+            _ANTHROPIC_FALLBACK_ENV,
+            self._has_native_auth,
+        )
+        return env
+
     @with_prompt_template
     async def run(
         self,
@@ -212,7 +290,7 @@ class RunmeClaudeCode(ClaudeCode):
         cli_flags = self.build_cli_flags()
         cli_flags_arg = f"{cli_flags} " if cli_flags else ""
         session_files_before = self._snapshot_session_files()
-        env = self._runtime_env()
+        env = await self._agent_env(environment)
 
         try:
             await self.exec_as_agent(
@@ -367,6 +445,35 @@ class RunmeCodex(Codex):
         shutil.copy2(session_file, target)
         return True
 
+    async def _has_native_auth(
+        self,
+        environment: BaseEnvironment,
+        env: dict[str, str],
+    ) -> bool | None:
+        return await _command_succeeds(
+            environment,
+            "if [ -s ~/.nvm/nvm.sh ]; then . ~/.nvm/nvm.sh; fi; codex login status",
+            env=env,
+        )
+
+    async def _agent_env(self, environment: BaseEnvironment) -> dict[str, str]:
+        env: dict[str, str] = {}
+        await _promote_fallback_auth(
+            self,
+            environment,
+            env,
+            "OPENAI_API_KEY",
+            _OPENAI_FALLBACK_ENV,
+            self._has_native_auth,
+        )
+        return env
+
+    def _openai_base_url_arg(self) -> str:
+        base_url = self._get_env("OPENAI_BASE_URL")
+        if not base_url:
+            return ""
+        return f"-c {_config_arg('openai_base_url', base_url)} "
+
     @with_prompt_template
     async def run(
         self,
@@ -380,7 +487,9 @@ class RunmeCodex(Codex):
 
         cli_flags = self.build_cli_flags()
         cli_flags_arg = f"{cli_flags} " if cli_flags else ""
+        base_url_arg = self._openai_base_url_arg()
         session_files_before = self._snapshot_session_files()
+        env = await self._agent_env(environment)
 
         try:
             await self.exec_as_agent(
@@ -391,6 +500,7 @@ class RunmeCodex(Codex):
                     "codex exec "
                     "--dangerously-bypass-approvals-and-sandbox "
                     "--skip-git-repo-check "
+                    f"{base_url_arg}"
                     f"{model_arg}"
                     "--json "
                     "--enable unified_exec "
@@ -400,6 +510,7 @@ class RunmeCodex(Codex):
                     f"2>&1 </dev/null | tee "
                     f"{EnvironmentPaths.agent_dir / self._OUTPUT_FILENAME}"
                 ),
+                env=env,
             )
         finally:
             collected_session = False

--- a/integrations/harbor/src/runme_harbor/runme_agents.py
+++ b/integrations/harbor/src/runme_harbor/runme_agents.py
@@ -75,6 +75,7 @@ async def _promote_fallback_auth(
     if native_auth_first and fallback:
         native_auth = await native_auth_probe(environment, env)
         if native_auth is True:
+            env.pop(provider_key, None)
             return "native"
         if native_auth is None:
             return "indeterminate"
@@ -88,6 +89,7 @@ async def _promote_fallback_auth(
     if not native_auth_first:
         native_auth = await native_auth_probe(environment, env)
         if native_auth is True:
+            env.pop(provider_key, None)
             return "native"
         if native_auth is None:
             return "indeterminate"
@@ -268,7 +270,8 @@ class RunmeClaudeCode(ClaudeCode):
     ) -> bool | None:
         return await _command_succeeds(
             environment,
-            'export PATH="$HOME/.local/bin:$PATH"; claude auth status',
+            'unset ANTHROPIC_API_KEY; export PATH="$HOME/.local/bin:$PATH"; '
+            "claude auth status",
             env=env,
         )
 

--- a/integrations/harbor/tests/test_environment.py
+++ b/integrations/harbor/tests/test_environment.py
@@ -157,6 +157,55 @@ def test_exec_merges_persistent_per_call_and_scoped_env(
     assert "SHARED=persistent" not in request_env
 
 
+def test_scoped_agent_env_does_not_leak_to_verifier_phase(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    FakeClient.instances.clear()
+    monkeypatch.setattr(env_module, "_StdioClient", FakeClient)
+
+    environment = _make_env(
+        tmp_path,
+        persistent_env={
+            "ANTHROPIC_API_KEY": "judge-key",
+            "ANTHROPIC_BASE_URL": "https://judge.example/v1",
+        },
+    )
+
+    asyncio.run(environment.start(force_build=False))
+
+    with environment.scoped_exec_env(
+        {
+            "RUNME_ROUTER_FALLBACK_ANTHROPIC_API_KEY": "agent-fallback",
+            "ANTHROPIC_BASE_URL": "https://agent-router.example/v1",
+        }
+    ):
+        asyncio.run(
+            environment.exec(
+                "agent",
+                env={"ANTHROPIC_API_KEY": "promoted-agent-fallback"},
+            )
+        )
+
+    asyncio.run(environment.exec("verifier", env={"VERIFIER_ENV": "yes"}))
+
+    client = FakeClient.instances[0]
+    agent_env = client.requests[-2]["exec"]["env"]
+    verifier_env = client.requests[-1]["exec"]["env"]
+
+    assert "ANTHROPIC_API_KEY=agent-fallback" not in agent_env
+    assert "ANTHROPIC_API_KEY=promoted-agent-fallback" in agent_env
+    assert "ANTHROPIC_BASE_URL=https://agent-router.example/v1" in agent_env
+    assert "RUNME_ROUTER_FALLBACK_ANTHROPIC_API_KEY=agent-fallback" in agent_env
+
+    assert "ANTHROPIC_API_KEY=judge-key" in verifier_env
+    assert "ANTHROPIC_BASE_URL=https://judge.example/v1" in verifier_env
+    assert "VERIFIER_ENV=yes" in verifier_env
+    assert "ANTHROPIC_API_KEY=promoted-agent-fallback" not in verifier_env
+    assert "ANTHROPIC_BASE_URL=https://agent-router.example/v1" not in verifier_env
+    assert all(not item.startswith("RUNME_ROUTER_FALLBACK_") for item in verifier_env)
+
+
 def test_stdio_client_allows_large_protojson_lines(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, Any] = {}
 
@@ -370,9 +419,7 @@ def test_upload_dir_rewrites_configured_workdir_paths_to_staged_workdir(
 
     tests = tmp_path / "tests"
     tests.mkdir()
-    (tests / "test.sh").write_text(
-        "rewardkit --workspace /app/examples/harbor/task/workdir\n"
-    )
+    (tests / "test.sh").write_text("rewardkit --workspace /app/examples/harbor/task/workdir\n")
 
     environment = _make_env(
         tmp_path,
@@ -498,8 +545,7 @@ def test_upload_dir_rewrites_artifact_paths_in_shell_scripts(
     source = tmp_path / "source"
     source.mkdir()
     (source / "test.sh").write_text(
-        "mkdir -p /logs/artifacts\n"
-        "cp results.json /logs/artifacts/results.json\n"
+        "mkdir -p /logs/artifacts\ncp results.json /logs/artifacts/results.json\n"
     )
 
     environment = _make_env(tmp_path)
@@ -547,9 +593,7 @@ def test_upload_dir_rewrites_python_artifact_paths(
 
     source = tmp_path / "source"
     source.mkdir()
-    (source / "artifact.py").write_text(
-        'Path("/logs/artifacts/results.json").write_text("{}")\n'
-    )
+    (source / "artifact.py").write_text('Path("/logs/artifacts/results.json").write_text("{}")\n')
 
     environment = _make_env(tmp_path)
     asyncio.run(environment.start(force_build=False))

--- a/integrations/harbor/tests/test_runme_antigravity_cli.py
+++ b/integrations/harbor/tests/test_runme_antigravity_cli.py
@@ -106,7 +106,7 @@ def test_runme_antigravity_cli_can_use_local_default_model(tmp_path: Path) -> No
     assert "--prompt='write result.txt'" in calls[1][0]
 
 
-def test_runme_antigravity_cli_does_not_promote_google_fallback(
+def test_runme_antigravity_cli_promotes_google_fallback(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -136,9 +136,80 @@ def test_runme_antigravity_cli_does_not_promote_google_fallback(
 
     for _, env in calls[:2]:
         assert env.get("GEMINI_CLI_TRUST_WORKSPACE") == "true"
-        assert "GEMINI_API_KEY" not in env
+        assert env["GEMINI_API_KEY"] == "fallback-key"
         assert "GOOGLE_API_KEY" not in env
         assert "RUNME_ROUTER_FALLBACK_GOOGLE_API_KEY" not in env
+
+
+@pytest.mark.parametrize("route_oauth_credentials", [False, "false"])
+def test_runme_antigravity_cli_native_auth_bypasses_router_by_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    route_oauth_credentials: bool | str,
+) -> None:
+    for var in (
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "RUNME_ROUTER_FALLBACK_GOOGLE_API_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("GOOGLE_GEMINI_BASE_URL", "https://router.test/gemini")
+    monkeypatch.setenv("GOOGLE_VERTEX_BASE_URL", "https://router.test/vertex")
+    agent = RunmeAntigravityCli(
+        logs_dir=tmp_path,
+        route_oauth_credentials=route_oauth_credentials,
+    )
+    calls: list[tuple[str, dict[str, str] | None]] = []
+
+    async def fake_exec_as_agent(
+        _environment: Any,
+        command: str,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        calls.append((command, env))
+
+    agent.exec_as_agent = fake_exec_as_agent
+    agent.populate_context_post_run = lambda _context: None
+    asyncio.run(agent.run("write result.txt", FakeEnvironment(), object()))
+
+    for _, env in calls[:2]:
+        assert "GOOGLE_GEMINI_BASE_URL" not in (env or {})
+        assert "GOOGLE_VERTEX_BASE_URL" not in (env or {})
+
+
+def test_runme_antigravity_cli_routes_native_auth_when_enabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("RUNME_ROUTER_FALLBACK_GOOGLE_API_KEY", raising=False)
+    monkeypatch.setenv("GOOGLE_GEMINI_BASE_URL", "https://router.test/gemini")
+    monkeypatch.setenv("GOOGLE_VERTEX_BASE_URL", "https://router.test/vertex")
+    agent = RunmeAntigravityCli(logs_dir=tmp_path, route_oauth_credentials=True)
+    calls: list[tuple[str, dict[str, str] | None]] = []
+
+    async def fake_exec_as_agent(
+        _environment: Any,
+        command: str,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        calls.append((command, env))
+
+    agent.exec_as_agent = fake_exec_as_agent
+    agent.populate_context_post_run = lambda _context: None
+    asyncio.run(agent.run("write result.txt", FakeEnvironment(), object()))
+
+    assert calls[0][1]["GOOGLE_GEMINI_BASE_URL"] == "https://router.test/gemini"
+    assert calls[0][1]["GOOGLE_VERTEX_BASE_URL"] == "https://router.test/vertex"
+
+
+@pytest.mark.parametrize("value", ["yes", "0", 1, None])
+def test_runme_antigravity_cli_rejects_invalid_oauth_routing_policy(
+    tmp_path: Path, value: object
+) -> None:
+    with pytest.raises(ValueError, match="route_oauth_credentials must be true or false"):
+        RunmeAntigravityCli(logs_dir=tmp_path, route_oauth_credentials=value)
 
 
 def test_runme_antigravity_cli_rejects_unqualified_model(tmp_path: Path) -> None:

--- a/integrations/harbor/tests/test_runme_antigravity_cli.py
+++ b/integrations/harbor/tests/test_runme_antigravity_cli.py
@@ -36,12 +36,15 @@ def test_runme_antigravity_cli_uses_ambient_user_auth(
         "GOOGLE_APPLICATION_CREDENTIALS",
         "GOOGLE_CLOUD_PROJECT",
         "GOOGLE_CLOUD_LOCATION",
+        "GOOGLE_GEMINI_BASE_URL",
         "GOOGLE_GENAI_USE_VERTEXAI",
+        "GOOGLE_VERTEX_BASE_URL",
         "GOOGLE_API_KEY",
     ):
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("GEMINI_API_KEY", "ambient-key")
     monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "ambient-project")
+    monkeypatch.setenv("GOOGLE_GEMINI_BASE_URL", "https://router.test/v1")
 
     environment = FakeEnvironment()
     agent = RunmeAntigravityCli(logs_dir=tmp_path, model_name="google/gemini-3-pro-preview")
@@ -71,6 +74,7 @@ def test_runme_antigravity_cli_uses_ambient_user_auth(
     assert calls[0][1] == {
         "GEMINI_API_KEY": "ambient-key",
         "GEMINI_CLI_TRUST_WORKSPACE": "true",
+        "GOOGLE_GEMINI_BASE_URL": "https://router.test/v1",
         "GOOGLE_CLOUD_PROJECT": "ambient-project",
     }
     assert calls[1][1] == calls[0][1]
@@ -100,6 +104,41 @@ def test_runme_antigravity_cli_can_use_local_default_model(tmp_path: Path) -> No
     assert "defaultModel" not in calls[0][0]
     assert "--model " not in calls[1][0]
     assert "--prompt='write result.txt'" in calls[1][0]
+
+
+def test_runme_antigravity_cli_does_not_promote_google_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for var in (
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "RUNME_ROUTER_FALLBACK_GOOGLE_API_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("RUNME_ROUTER_FALLBACK_GOOGLE_API_KEY", "fallback-key")
+
+    environment = FakeEnvironment()
+    agent = RunmeAntigravityCli(logs_dir=tmp_path, model_name="google/gemini-3-pro-preview")
+    calls: list[tuple[str, dict[str, str] | None]] = []
+
+    async def fake_exec_as_agent(
+        _environment: Any,
+        command: str,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        calls.append((command, env))
+
+    agent.exec_as_agent = fake_exec_as_agent
+    agent.populate_context_post_run = lambda _context: None
+
+    asyncio.run(agent.run("write result.txt", environment, object()))
+
+    for _, env in calls[:2]:
+        assert env.get("GEMINI_CLI_TRUST_WORKSPACE") == "true"
+        assert "GEMINI_API_KEY" not in env
+        assert "GOOGLE_API_KEY" not in env
+        assert "RUNME_ROUTER_FALLBACK_GOOGLE_API_KEY" not in env
 
 
 def test_runme_antigravity_cli_rejects_unqualified_model(tmp_path: Path) -> None:

--- a/integrations/harbor/tests/test_runme_claude_code.py
+++ b/integrations/harbor/tests/test_runme_claude_code.py
@@ -123,6 +123,23 @@ def test_runme_claude_code_native_login_wins_over_ambient_key_and_fallback(
     assert env["ANTHROPIC_BASE_URL"] == "https://router.test/v1"
 
 
+def test_runme_claude_code_native_probe_unsets_api_key(tmp_path: Path) -> None:
+    environment = FakeEnvironment()
+    agent = RunmeClaudeCode(logs_dir=tmp_path)
+    calls: list[tuple[str, dict[str, str] | None]] = []
+
+    async def fake_exec(
+        *, command: str, env: dict[str, str] | None = None, **_kwargs: Any
+    ) -> Any:
+        calls.append((command, env))
+        return type("Result", (), {"return_code": 0})()
+
+    environment.exec = fake_exec
+
+    assert asyncio.run(agent._has_native_auth(environment, {"ANTHROPIC_API_KEY": "key"}))
+    assert calls[0][0].startswith("unset ANTHROPIC_API_KEY;")
+
+
 def test_runme_claude_code_native_login_wins_over_fallback(
     tmp_path: Path,
     monkeypatch,

--- a/integrations/harbor/tests/test_runme_claude_code.py
+++ b/integrations/harbor/tests/test_runme_claude_code.py
@@ -73,6 +73,104 @@ def test_runme_claude_code_preserves_model_name_with_custom_base_url(
     assert agent._model_arg() == "--model openrouter/anthropic/haiku "
 
 
+def test_runme_claude_code_reads_base_url_from_resolved_env(tmp_path: Path) -> None:
+    agent = RunmeClaudeCode(
+        logs_dir=tmp_path,
+        model_name="openrouter/anthropic/haiku",
+        extra_env={"ANTHROPIC_BASE_URL": "https://router.test"},
+    )
+
+    assert agent._model_arg() == "--model openrouter/anthropic/haiku "
+
+
+def test_runme_claude_code_preserves_explicit_anthropic_key_over_fallback(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "explicit-key")
+    monkeypatch.setenv("RUNME_ROUTER_FALLBACK_ANTHROPIC_API_KEY", "fallback-key")
+
+    environment = FakeEnvironment()
+    agent = RunmeClaudeCode(logs_dir=tmp_path)
+
+    async def fail_if_called(_environment: Any, _env: dict[str, str]) -> bool:
+        raise AssertionError("native auth should not be probed when explicit key exists")
+
+    agent._has_native_auth = fail_if_called
+
+    assert "ANTHROPIC_API_KEY" not in asyncio.run(agent._agent_env(environment))
+
+
+def test_runme_claude_code_native_login_wins_over_fallback(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("RUNME_ROUTER_FALLBACK_ANTHROPIC_API_KEY", "fallback-key")
+
+    environment = FakeEnvironment()
+    agent = RunmeClaudeCode(logs_dir=tmp_path)
+
+    async def fake_has_native_auth(_environment: Any, _env: dict[str, str]) -> bool:
+        return True
+
+    agent._has_native_auth = fake_has_native_auth
+
+    assert "ANTHROPIC_API_KEY" not in asyncio.run(agent._agent_env(environment))
+
+
+def test_runme_claude_code_promotes_fallback_when_auth_gap_exists(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("RUNME_ROUTER_FALLBACK_ANTHROPIC_API_KEY", "fallback-key")
+
+    environment = FakeEnvironment()
+    agent = RunmeClaudeCode(logs_dir=tmp_path)
+
+    async def fake_has_native_auth(_environment: Any, _env: dict[str, str]) -> bool:
+        return False
+
+    agent._has_native_auth = fake_has_native_auth
+
+    env = asyncio.run(agent._agent_env(environment))
+
+    assert env["ANTHROPIC_API_KEY"] == "fallback-key"
+
+
+def test_runme_claude_code_fails_closed_when_login_detection_is_indeterminate(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("RUNME_ROUTER_FALLBACK_ANTHROPIC_API_KEY", "fallback-key")
+
+    environment = FakeEnvironment()
+    agent = RunmeClaudeCode(logs_dir=tmp_path)
+
+    async def fake_has_native_auth(_environment: Any, _env: dict[str, str]) -> None:
+        return None
+
+    agent._has_native_auth = fake_has_native_auth
+
+    assert "ANTHROPIC_API_KEY" not in asyncio.run(agent._agent_env(environment))
+
+
+def test_runme_claude_code_passes_base_url_through_process_env(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://router.test/v1")
+
+    environment = FakeEnvironment()
+    agent = RunmeClaudeCode(logs_dir=tmp_path)
+
+    env = asyncio.run(agent._agent_env(environment))
+
+    assert env["ANTHROPIC_BASE_URL"] == "https://router.test/v1"
+
+
 def test_runme_claude_code_collects_only_new_sessions(
     tmp_path: Path,
     monkeypatch,

--- a/integrations/harbor/tests/test_runme_claude_code.py
+++ b/integrations/harbor/tests/test_runme_claude_code.py
@@ -2,6 +2,8 @@ import asyncio
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from runme_harbor.runme_agents import RunmeClaudeCode
 
 
@@ -120,7 +122,7 @@ def test_runme_claude_code_native_login_wins_over_ambient_key_and_fallback(
     env = asyncio.run(agent._agent_env(environment))
 
     assert "ANTHROPIC_API_KEY" not in env
-    assert env["ANTHROPIC_BASE_URL"] == "https://router.test/v1"
+    assert "ANTHROPIC_BASE_URL" not in env
 
 
 def test_runme_claude_code_native_run_unsets_inherited_api_key(
@@ -159,16 +161,14 @@ def test_runme_claude_code_native_probe_unsets_api_key(tmp_path: Path) -> None:
     agent = RunmeClaudeCode(logs_dir=tmp_path)
     calls: list[tuple[str, dict[str, str] | None]] = []
 
-    async def fake_exec(
-        *, command: str, env: dict[str, str] | None = None, **_kwargs: Any
-    ) -> Any:
+    async def fake_exec(*, command: str, env: dict[str, str] | None = None, **_kwargs: Any) -> Any:
         calls.append((command, env))
         return type("Result", (), {"return_code": 0})()
 
     environment.exec = fake_exec
 
     assert asyncio.run(agent._has_native_auth(environment, {"ANTHROPIC_API_KEY": "key"}))
-    assert calls[0][0].startswith("unset ANTHROPIC_API_KEY;")
+    assert calls[0][0].startswith("unset ANTHROPIC_API_KEY ANTHROPIC_BASE_URL;")
 
 
 def test_runme_claude_code_native_login_wins_over_fallback(
@@ -227,7 +227,7 @@ def test_runme_claude_code_fails_closed_when_login_detection_is_indeterminate(
     assert "ANTHROPIC_API_KEY" not in asyncio.run(agent._agent_env(environment))
 
 
-def test_runme_claude_code_passes_base_url_through_process_env(
+def test_runme_claude_code_indeterminate_auth_bypasses_base_url_by_default(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -238,7 +238,34 @@ def test_runme_claude_code_passes_base_url_through_process_env(
 
     env = asyncio.run(agent._agent_env(environment))
 
+    assert "ANTHROPIC_BASE_URL" not in env
+
+
+def test_runme_claude_code_routes_native_auth_when_enabled(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("RUNME_ROUTER_FALLBACK_ANTHROPIC_API_KEY", "fallback-key")
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://router.test/v1")
+    environment = FakeEnvironment()
+    agent = RunmeClaudeCode(logs_dir=tmp_path, route_oauth_credentials="true")
+
+    async def fake_has_native_auth(_environment: Any, _env: dict[str, str]) -> bool:
+        return True
+
+    agent._has_native_auth = fake_has_native_auth
+    env = asyncio.run(agent._agent_env(environment))
+
+    assert "ANTHROPIC_API_KEY" not in env
     assert env["ANTHROPIC_BASE_URL"] == "https://router.test/v1"
+
+
+@pytest.mark.parametrize("value", ["yes", "0", 1, None])
+def test_runme_claude_code_rejects_invalid_oauth_routing_policy(
+    tmp_path: Path, value: object
+) -> None:
+    with pytest.raises(ValueError, match="route_oauth_credentials must be true or false"):
+        RunmeClaudeCode(logs_dir=tmp_path, route_oauth_credentials=value)
 
 
 def test_runme_claude_code_collects_only_new_sessions(

--- a/integrations/harbor/tests/test_runme_claude_code.py
+++ b/integrations/harbor/tests/test_runme_claude_code.py
@@ -123,6 +123,37 @@ def test_runme_claude_code_native_login_wins_over_ambient_key_and_fallback(
     assert env["ANTHROPIC_BASE_URL"] == "https://router.test/v1"
 
 
+def test_runme_claude_code_native_run_unsets_inherited_api_key(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "judge-key")
+    monkeypatch.setenv("RUNME_ROUTER_FALLBACK_ANTHROPIC_API_KEY", "fallback-key")
+    environment = FakeEnvironment()
+    agent = RunmeClaudeCode(logs_dir=tmp_path)
+    calls: list[tuple[str, dict[str, str] | None]] = []
+
+    async def fake_has_native_auth(_environment: Any, _env: dict[str, str]) -> bool:
+        return True
+
+    async def fake_exec_as_agent(
+        _environment: Any,
+        command: str,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        calls.append((command, env))
+
+    agent._has_native_auth = fake_has_native_auth
+    agent.exec_as_agent = fake_exec_as_agent
+    agent.populate_context_post_run = lambda _context: None
+
+    asyncio.run(agent.run("write result.txt", environment, object()))
+
+    command, env = calls[0]
+    assert "set -o pipefail\nunset ANTHROPIC_API_KEY\nclaude " in command
+    assert "ANTHROPIC_API_KEY" not in (env or {})
+
+
 def test_runme_claude_code_native_probe_unsets_api_key(tmp_path: Path) -> None:
     environment = FakeEnvironment()
     agent = RunmeClaudeCode(logs_dir=tmp_path)

--- a/integrations/harbor/tests/test_runme_claude_code.py
+++ b/integrations/harbor/tests/test_runme_claude_code.py
@@ -93,12 +93,34 @@ def test_runme_claude_code_preserves_explicit_anthropic_key_over_fallback(
     environment = FakeEnvironment()
     agent = RunmeClaudeCode(logs_dir=tmp_path)
 
-    async def fail_if_called(_environment: Any, _env: dict[str, str]) -> bool:
-        raise AssertionError("native auth should not be probed when explicit key exists")
+    async def fake_has_native_auth(_environment: Any, _env: dict[str, str]) -> bool:
+        return False
 
-    agent._has_native_auth = fail_if_called
+    agent._has_native_auth = fake_has_native_auth
 
     assert "ANTHROPIC_API_KEY" not in asyncio.run(agent._agent_env(environment))
+
+
+def test_runme_claude_code_native_login_wins_over_ambient_key_and_fallback(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "judge-key")
+    monkeypatch.setenv("RUNME_ROUTER_FALLBACK_ANTHROPIC_API_KEY", "fallback-key")
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://router.test/v1")
+
+    environment = FakeEnvironment()
+    agent = RunmeClaudeCode(logs_dir=tmp_path)
+
+    async def fake_has_native_auth(_environment: Any, _env: dict[str, str]) -> bool:
+        return True
+
+    agent._has_native_auth = fake_has_native_auth
+
+    env = asyncio.run(agent._agent_env(environment))
+
+    assert "ANTHROPIC_API_KEY" not in env
+    assert env["ANTHROPIC_BASE_URL"] == "https://router.test/v1"
 
 
 def test_runme_claude_code_native_login_wins_over_fallback(

--- a/integrations/harbor/tests/test_runme_codex.py
+++ b/integrations/harbor/tests/test_runme_codex.py
@@ -83,7 +83,7 @@ def test_runme_codex_routes_through_process_local_base_url(
     assert "OPENAI_BASE_URL" not in command
 
 
-def test_runme_codex_preserves_explicit_openai_key_over_fallback(
+def test_runme_codex_uses_explicit_openai_key_when_native_login_is_absent(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -93,10 +93,10 @@ def test_runme_codex_preserves_explicit_openai_key_over_fallback(
     environment = FakeEnvironment()
     agent = RunmeCodex(logs_dir=tmp_path)
 
-    async def fail_if_called(_environment: Any, _env: dict[str, str]) -> bool:
-        raise AssertionError("native auth should not be probed when explicit key exists")
+    async def fake_has_native_auth(_environment: Any, _env: dict[str, str]) -> bool:
+        return False
 
-    agent._has_native_auth = fail_if_called
+    agent._has_native_auth = fake_has_native_auth
 
     assert asyncio.run(agent._agent_env_and_router_state(environment)) == ({}, True)
 
@@ -120,7 +120,7 @@ def test_runme_codex_native_login_bypasses_router_base_url(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "judge-key")
     monkeypatch.setenv("RUNME_ROUTER_FALLBACK_OPENAI_API_KEY", "fallback-key")
     monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:4000/router/v1/openai/v1")
 
@@ -146,6 +146,7 @@ def test_runme_codex_native_login_bypasses_router_base_url(
 
     command, env = calls[0]
     assert "openai_base_url" not in command
+    assert "unset OPENAI_API_KEY OPENAI_BASE_URL\n" in command
     assert "OPENAI_API_KEY" not in (env or {})
 
 
@@ -179,6 +180,7 @@ def test_runme_codex_promoted_fallback_keeps_router_base_url(
 
     command, env = calls[0]
     assert "openai_base_url" in command
+    assert "unset OPENAI_API_KEY OPENAI_BASE_URL\n" not in command
     assert (env or {}).get("OPENAI_API_KEY") == "fallback-key"
 
 

--- a/integrations/harbor/tests/test_runme_codex.py
+++ b/integrations/harbor/tests/test_runme_codex.py
@@ -102,7 +102,10 @@ def test_runme_codex_uses_explicit_openai_key_when_native_login_is_absent(
 
     agent._has_native_auth = fake_has_native_auth
 
-    assert asyncio.run(agent._agent_env_and_router_state(environment)) == ({}, True)
+    assert asyncio.run(agent._agent_env_and_router_state(environment)) == (
+        {},
+        "explicit",
+    )
 
 
 def test_runme_codex_native_login_wins_over_fallback(tmp_path: Path, monkeypatch) -> None:
@@ -117,10 +120,10 @@ def test_runme_codex_native_login_wins_over_fallback(tmp_path: Path, monkeypatch
 
     agent._has_native_auth = fake_has_native_auth
 
-    assert asyncio.run(agent._agent_env_and_router_state(environment)) == ({}, False)
+    assert asyncio.run(agent._agent_env_and_router_state(environment)) == ({}, "native")
 
 
-def test_runme_codex_native_login_bypasses_router_base_url(
+def test_runme_codex_native_login_routes_with_builtin_provider(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -150,6 +153,8 @@ def test_runme_codex_native_login_bypasses_router_base_url(
 
     command, env = calls[0]
     assert "model_provider" not in command
+    assert "openai_base_url" in command
+    assert "localhost:4000/router/v1/openai/v1" in command
     assert "unset OPENAI_API_KEY OPENAI_BASE_URL\n" in command
     assert "OPENAI_API_KEY" not in (env or {})
 
@@ -207,7 +212,7 @@ def test_runme_codex_promotes_fallback_when_auth_gap_exists(
 
     assert asyncio.run(agent._agent_env_and_router_state(environment)) == (
         {"OPENAI_API_KEY": "fallback-key"},
-        True,
+        "fallback",
     )
 
 
@@ -226,7 +231,10 @@ def test_runme_codex_fails_closed_when_login_detection_is_indeterminate(
 
     agent._has_native_auth = fake_has_native_auth
 
-    assert asyncio.run(agent._agent_env_and_router_state(environment)) == ({}, False)
+    assert asyncio.run(agent._agent_env_and_router_state(environment)) == (
+        {},
+        "indeterminate",
+    )
 
 
 def test_runme_codex_collects_only_new_sessions(

--- a/integrations/harbor/tests/test_runme_codex.py
+++ b/integrations/harbor/tests/test_runme_codex.py
@@ -98,7 +98,7 @@ def test_runme_codex_preserves_explicit_openai_key_over_fallback(
 
     agent._has_native_auth = fail_if_called
 
-    assert asyncio.run(agent._agent_env(environment)) == {}
+    assert asyncio.run(agent._agent_env_and_router_state(environment)) == ({}, True)
 
 
 def test_runme_codex_native_login_wins_over_fallback(tmp_path: Path, monkeypatch) -> None:
@@ -113,7 +113,73 @@ def test_runme_codex_native_login_wins_over_fallback(tmp_path: Path, monkeypatch
 
     agent._has_native_auth = fake_has_native_auth
 
-    assert asyncio.run(agent._agent_env(environment)) == {}
+    assert asyncio.run(agent._agent_env_and_router_state(environment)) == ({}, False)
+
+
+def test_runme_codex_native_login_bypasses_router_base_url(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("RUNME_ROUTER_FALLBACK_OPENAI_API_KEY", "fallback-key")
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:4000/router/v1/openai/v1")
+
+    environment = FakeEnvironment()
+    agent = RunmeCodex(logs_dir=tmp_path, model_name="openai/gpt-5")
+    calls: list[tuple[str, dict[str, str] | None]] = []
+
+    async def fake_has_native_auth(_environment: Any, _env: dict[str, str]) -> bool:
+        return True
+
+    async def fake_exec_as_agent(
+        _environment: Any,
+        command: str,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        calls.append((command, env))
+
+    agent._has_native_auth = fake_has_native_auth
+    agent.exec_as_agent = fake_exec_as_agent
+    agent.populate_context_post_run = lambda _context: None
+
+    asyncio.run(agent.run("write result.txt", environment, object()))
+
+    command, env = calls[0]
+    assert "openai_base_url" not in command
+    assert "OPENAI_API_KEY" not in (env or {})
+
+
+def test_runme_codex_promoted_fallback_keeps_router_base_url(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("RUNME_ROUTER_FALLBACK_OPENAI_API_KEY", "fallback-key")
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:4000/router/v1/openai/v1")
+
+    environment = FakeEnvironment()
+    agent = RunmeCodex(logs_dir=tmp_path, model_name="openai/gpt-5")
+    calls: list[tuple[str, dict[str, str] | None]] = []
+
+    async def fake_has_native_auth(_environment: Any, _env: dict[str, str]) -> bool:
+        return False
+
+    async def fake_exec_as_agent(
+        _environment: Any,
+        command: str,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        calls.append((command, env))
+
+    agent._has_native_auth = fake_has_native_auth
+    agent.exec_as_agent = fake_exec_as_agent
+    agent.populate_context_post_run = lambda _context: None
+
+    asyncio.run(agent.run("write result.txt", environment, object()))
+
+    command, env = calls[0]
+    assert "openai_base_url" in command
+    assert (env or {}).get("OPENAI_API_KEY") == "fallback-key"
 
 
 def test_runme_codex_promotes_fallback_when_auth_gap_exists(
@@ -131,7 +197,10 @@ def test_runme_codex_promotes_fallback_when_auth_gap_exists(
 
     agent._has_native_auth = fake_has_native_auth
 
-    assert asyncio.run(agent._agent_env(environment)) == {"OPENAI_API_KEY": "fallback-key"}
+    assert asyncio.run(agent._agent_env_and_router_state(environment)) == (
+        {"OPENAI_API_KEY": "fallback-key"},
+        True,
+    )
 
 
 def test_runme_codex_fails_closed_when_login_detection_is_indeterminate(
@@ -149,7 +218,7 @@ def test_runme_codex_fails_closed_when_login_detection_is_indeterminate(
 
     agent._has_native_auth = fake_has_native_auth
 
-    assert asyncio.run(agent._agent_env(environment)) == {}
+    assert asyncio.run(agent._agent_env_and_router_state(environment)) == ({}, False)
 
 
 def test_runme_codex_collects_only_new_sessions(

--- a/integrations/harbor/tests/test_runme_codex.py
+++ b/integrations/harbor/tests/test_runme_codex.py
@@ -51,6 +51,107 @@ def test_runme_codex_uses_ambient_user_auth(
     assert all("register" not in command for command, _ in calls)
 
 
+def test_runme_codex_routes_through_process_local_base_url(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "OPENAI_BASE_URL",
+        'https://router.test/v1?tenant=runme&note="quoted"',
+    )
+
+    environment = FakeEnvironment()
+    agent = RunmeCodex(logs_dir=tmp_path, model_name="openai/gpt-5")
+    calls: list[tuple[str, dict[str, str] | None]] = []
+
+    async def fake_exec_as_agent(
+        _environment: Any,
+        command: str,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        calls.append((command, env))
+
+    agent.exec_as_agent = fake_exec_as_agent
+    agent.populate_context_post_run = lambda _context: None
+
+    asyncio.run(agent.run("write result.txt", environment, object()))
+
+    command = calls[0][0]
+    assert "codex exec " in command
+    assert "-c 'openai_base_url=" in command
+    assert '\\"quoted\\"' in command
+    assert "OPENAI_BASE_URL" not in command
+
+
+def test_runme_codex_preserves_explicit_openai_key_over_fallback(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "explicit-key")
+    monkeypatch.setenv("RUNME_ROUTER_FALLBACK_OPENAI_API_KEY", "fallback-key")
+
+    environment = FakeEnvironment()
+    agent = RunmeCodex(logs_dir=tmp_path)
+
+    async def fail_if_called(_environment: Any, _env: dict[str, str]) -> bool:
+        raise AssertionError("native auth should not be probed when explicit key exists")
+
+    agent._has_native_auth = fail_if_called
+
+    assert asyncio.run(agent._agent_env(environment)) == {}
+
+
+def test_runme_codex_native_login_wins_over_fallback(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("RUNME_ROUTER_FALLBACK_OPENAI_API_KEY", "fallback-key")
+
+    environment = FakeEnvironment()
+    agent = RunmeCodex(logs_dir=tmp_path)
+
+    async def fake_has_native_auth(_environment: Any, _env: dict[str, str]) -> bool:
+        return True
+
+    agent._has_native_auth = fake_has_native_auth
+
+    assert asyncio.run(agent._agent_env(environment)) == {}
+
+
+def test_runme_codex_promotes_fallback_when_auth_gap_exists(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("RUNME_ROUTER_FALLBACK_OPENAI_API_KEY", "fallback-key")
+
+    environment = FakeEnvironment()
+    agent = RunmeCodex(logs_dir=tmp_path)
+
+    async def fake_has_native_auth(_environment: Any, _env: dict[str, str]) -> bool:
+        return False
+
+    agent._has_native_auth = fake_has_native_auth
+
+    assert asyncio.run(agent._agent_env(environment)) == {"OPENAI_API_KEY": "fallback-key"}
+
+
+def test_runme_codex_fails_closed_when_login_detection_is_indeterminate(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("RUNME_ROUTER_FALLBACK_OPENAI_API_KEY", "fallback-key")
+
+    environment = FakeEnvironment()
+    agent = RunmeCodex(logs_dir=tmp_path)
+
+    async def fake_has_native_auth(_environment: Any, _env: dict[str, str]) -> None:
+        return None
+
+    agent._has_native_auth = fake_has_native_auth
+
+    assert asyncio.run(agent._agent_env(environment)) == {}
+
+
 def test_runme_codex_collects_only_new_sessions(
     tmp_path: Path,
     monkeypatch,
@@ -99,9 +200,7 @@ def test_runme_codex_collects_session_matching_thread_id(
     )
 
     session_a.write_text('{"type":"session_meta","payload":{"id":"session-a"}}\n')
-    session_b.write_text(
-        '{"type":"session_meta","payload":{"session_id":"session-b"}}\n'
-    )
+    session_b.write_text('{"type":"session_meta","payload":{"session_id":"session-b"}}\n')
 
     assert agent._collect_new_sessions(before)
 

--- a/integrations/harbor/tests/test_runme_codex.py
+++ b/integrations/harbor/tests/test_runme_codex.py
@@ -2,6 +2,8 @@ import asyncio
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from runme_harbor.runme_agents import RunmeCodex
 
 
@@ -59,9 +61,14 @@ def test_runme_codex_routes_through_process_local_base_url(
         "OPENAI_BASE_URL",
         'https://router.test/v1?tenant=runme&note="quoted"',
     )
+    monkeypatch.setenv("OPENAI_API_KEY", "explicit-key")
 
     environment = FakeEnvironment()
-    agent = RunmeCodex(logs_dir=tmp_path, model_name="openai/gpt-5")
+    agent = RunmeCodex(
+        logs_dir=tmp_path,
+        model_name="openai/gpt-5",
+        route_oauth_credentials="true",
+    )
     calls: list[tuple[str, dict[str, str] | None]] = []
 
     async def fake_exec_as_agent(
@@ -132,7 +139,11 @@ def test_runme_codex_native_login_routes_with_builtin_provider(
     monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:4000/router/v1/openai/v1")
 
     environment = FakeEnvironment()
-    agent = RunmeCodex(logs_dir=tmp_path, model_name="openai/gpt-5")
+    agent = RunmeCodex(
+        logs_dir=tmp_path,
+        model_name="openai/gpt-5",
+        route_oauth_credentials=True,
+    )
     calls: list[tuple[str, dict[str, str] | None]] = []
 
     async def fake_has_native_auth(_environment: Any, _env: dict[str, str]) -> bool:
@@ -157,6 +168,42 @@ def test_runme_codex_native_login_routes_with_builtin_provider(
     assert "localhost:4000/router/v1/openai/v1" in command
     assert "unset OPENAI_API_KEY OPENAI_BASE_URL\n" in command
     assert "OPENAI_API_KEY" not in (env or {})
+
+
+def test_runme_codex_native_login_bypasses_router_by_default(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("RUNME_ROUTER_FALLBACK_OPENAI_API_KEY", "fallback-key")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://router.test/v1")
+    agent = RunmeCodex(logs_dir=tmp_path, model_name="openai/gpt-5")
+    calls: list[tuple[str, dict[str, str] | None]] = []
+
+    async def fake_has_native_auth(_environment: Any, _env: dict[str, str]) -> bool:
+        return True
+
+    async def fake_exec_as_agent(
+        _environment: Any,
+        command: str,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        calls.append((command, env))
+
+    agent._has_native_auth = fake_has_native_auth
+    agent.exec_as_agent = fake_exec_as_agent
+    agent.populate_context_post_run = lambda _context: None
+
+    asyncio.run(agent.run("write result.txt", FakeEnvironment(), object()))
+
+    command, _ = calls[0]
+    assert "model_provider" not in command
+    assert "openai_base_url" not in command
+
+
+@pytest.mark.parametrize("value", ["yes", "0", 1, None])
+def test_runme_codex_rejects_invalid_oauth_routing_policy(tmp_path: Path, value: object) -> None:
+    with pytest.raises(ValueError, match="route_oauth_credentials must be true or false"):
+        RunmeCodex(logs_dir=tmp_path, route_oauth_credentials=value)
 
 
 def test_runme_codex_promoted_fallback_keeps_router_base_url(

--- a/integrations/harbor/tests/test_runme_codex.py
+++ b/integrations/harbor/tests/test_runme_codex.py
@@ -78,7 +78,11 @@ def test_runme_codex_routes_through_process_local_base_url(
 
     command = calls[0][0]
     assert "codex exec " in command
-    assert "-c 'openai_base_url=" in command
+    assert "model_provider" in command
+    assert "model_providers.runme_router.base_url" in command
+    assert "model_providers.runme_router.env_key" in command
+    assert "model_providers.runme_router.wire_api" in command
+    assert "model_providers.runme_router.supports_websockets=false" in command
     assert '\\"quoted\\"' in command
     assert "OPENAI_BASE_URL" not in command
 
@@ -145,7 +149,7 @@ def test_runme_codex_native_login_bypasses_router_base_url(
     asyncio.run(agent.run("write result.txt", environment, object()))
 
     command, env = calls[0]
-    assert "openai_base_url" not in command
+    assert "model_provider" not in command
     assert "unset OPENAI_API_KEY OPENAI_BASE_URL\n" in command
     assert "OPENAI_API_KEY" not in (env or {})
 
@@ -179,7 +183,9 @@ def test_runme_codex_promoted_fallback_keeps_router_base_url(
     asyncio.run(agent.run("write result.txt", environment, object()))
 
     command, env = calls[0]
-    assert "openai_base_url" in command
+    assert "model_provider" in command
+    assert "model_providers.runme_router.base_url" in command
+    assert "model_providers.runme_router.supports_websockets=false" in command
     assert "unset OPENAI_API_KEY OPENAI_BASE_URL\n" not in command
     assert (env or {}).get("OPENAI_API_KEY") == "fallback-key"
 

--- a/internal/harbor/eval.go
+++ b/internal/harbor/eval.go
@@ -17,27 +17,29 @@ const (
 var ErrRunmeHarborMissing = errors.New("runme-harbor missing")
 
 type EvalOptions struct {
-	Agent           string
-	TaskDir         string
-	JobsDir         string
-	Ask             bool
-	AgentKwargs     []string
-	AgentEnv        []string
-	Model           string
-	Env             string
-	RunmeBin        string
-	RunmeArgs       []string
-	RunmeHarborBin  string
-	Debug           bool
-	JobsDirExplicit bool
-	CommandRun      CommandRunFunc
-	LookPath        func(string) (string, error)
-	Executable      func() (string, error)
-	Stdin           io.Reader
-	Stdout          io.Writer
-	Stderr          io.Writer
-	ExtraEnv        []string
-	Preflight       bool
+	Agent              string
+	TaskDir            string
+	JobsDir            string
+	Ask                bool
+	AgentKwargs        []string
+	AgentEnv           []string
+	VerifierEnv        []string
+	VerifierEnvDefault []string
+	Model              string
+	Env                string
+	RunmeBin           string
+	RunmeArgs          []string
+	RunmeHarborBin     string
+	Debug              bool
+	JobsDirExplicit    bool
+	CommandRun         CommandRunFunc
+	LookPath           func(string) (string, error)
+	Executable         func() (string, error)
+	Stdin              io.Reader
+	Stdout             io.Writer
+	Stderr             io.Writer
+	ExtraEnv           []string
+	Preflight          bool
 }
 
 type CommandRunFunc func(name string, args []string, workingDir string, env []string, stdin io.Reader, stdout, stderr io.Writer) error
@@ -111,6 +113,10 @@ func (r *EvalRunner) Run(args []string) error {
 		env = setEnv(env, "RUNME_ARGS", joinShellArgs(opts.RunmeArgs))
 	}
 	env = append(env, opts.ExtraEnv...)
+	env, err = applyEnvDefaults(env, opts.VerifierEnvDefault)
+	if err != nil {
+		return fmt.Errorf("apply verifier environment defaults: %w", err)
+	}
 
 	delegatedArgs, err := harborRunArgsBuilder{
 		datasetPath: paths.delegateDatasetPath,
@@ -152,6 +158,28 @@ func (r *EvalRunner) Run(args []string) error {
 	}
 	r.syncMetadata(runmeHarbor, paths.delegateJobsDir, paths.executionCwd, env)
 	return err
+}
+
+func applyEnvDefaults(env []string, defaults []string) ([]string, error) {
+	for _, assignment := range defaults {
+		key, value, ok := strings.Cut(assignment, "=")
+		key = strings.TrimSpace(key)
+		if !ok || key == "" {
+			return nil, fmt.Errorf("invalid environment assignment %q: expected KEY=VALUE", assignment)
+		}
+		prefix := key + "="
+		configured := false
+		for _, item := range env {
+			if strings.HasPrefix(item, prefix) {
+				configured = true
+				break
+			}
+		}
+		if !configured {
+			env = append(env, prefix+value)
+		}
+	}
+	return env, nil
 }
 
 func (r *EvalRunner) syncMetadata(runmeHarbor, jobsDir, workingDir string, env []string) {

--- a/internal/harbor/eval_harbor_args.go
+++ b/internal/harbor/eval_harbor_args.go
@@ -25,6 +25,7 @@ var (
 	modelHarborFlag       = harborFlag{names: []string{"--model"}}
 	agentKwargHarborFlag  = harborFlag{names: []string{"--agent-kwarg", "--ak"}}
 	agentEnvHarborFlag    = harborFlag{names: []string{"--agent-env", "--ae"}}
+	verifierEnvHarborFlag = harborFlag{names: []string{"--verifier-env", "--ve"}}
 	environmentHarborFlag = harborFlag{
 		names:            []string{"--env", "-e", "--environment-import-path"},
 		allowJoinedShort: true,
@@ -78,6 +79,9 @@ func (b harborRunArgsBuilder) validate() error {
 	if len(b.opts.AgentEnv) > 0 && agentEnvHarborFlag.Present(b.passthrough) {
 		return fmt.Errorf("--agent-env cannot be used together with passthrough --agent-env/--ae; use only runme eval --agent-env")
 	}
+	if len(b.opts.VerifierEnv) > 0 && verifierEnvHarborFlag.Present(b.passthrough) {
+		return fmt.Errorf("--verifier-env cannot be used together with passthrough --verifier-env/--ve; use only runme eval --verifier-env")
+	}
 	if environmentHarborFlag.Present(b.passthrough) {
 		return fmt.Errorf("use runme eval --env instead of passing Harbor environment flags after --")
 	}
@@ -111,6 +115,9 @@ func (b harborRunArgsBuilder) extraArgs() []string {
 	}
 	for _, env := range b.opts.AgentEnv {
 		args = append(args, "--agent-env", env)
+	}
+	for _, env := range b.opts.VerifierEnv {
+		args = append(args, "--verifier-env", env)
 	}
 	if b.opts.Model != "" {
 		args = append(args, "--model", b.opts.Model)

--- a/internal/harbor/eval_harbor_args.go
+++ b/internal/harbor/eval_harbor_args.go
@@ -85,6 +85,15 @@ func (b harborRunArgsBuilder) validate() error {
 	if environmentHarborFlag.Present(b.passthrough) {
 		return fmt.Errorf("use runme eval --env instead of passing Harbor environment flags after --")
 	}
+	for _, kwarg := range b.opts.AgentKwargs {
+		name, value, ok := strings.Cut(kwarg, "=")
+		if strings.TrimSpace(name) != "route_oauth_credentials" {
+			continue
+		}
+		if !ok || (strings.ToLower(strings.TrimSpace(value)) != "true" && strings.ToLower(strings.TrimSpace(value)) != "false") {
+			return fmt.Errorf("route_oauth_credentials agent kwarg must be true or false")
+		}
+	}
 	return nil
 }
 

--- a/internal/harbor/eval_harbor_args.go
+++ b/internal/harbor/eval_harbor_args.go
@@ -14,9 +14,9 @@ const (
 var runmeAgentSpecs = []runmeAgentSpec{
 	{name: "oracle"},
 	{name: "nop"},
-	{name: "antigravity-cli", importPath: "runme_harbor.runme_agents:RunmeAntigravityCli"},
-	{name: "codex", importPath: "runme_harbor.runme_agents:RunmeCodex"},
-	{name: "claude-code", importPath: "runme_harbor.runme_agents:RunmeClaudeCode"},
+	{name: "antigravity-cli", importPath: "runme_harbor.runme_agents:RunmeAntigravityCli", routeOAuthCredentials: true},
+	{name: "codex", importPath: "runme_harbor.runme_agents:RunmeCodex", routeOAuthCredentials: true},
+	{name: "claude-code", importPath: "runme_harbor.runme_agents:RunmeClaudeCode", routeOAuthCredentials: true},
 	{name: "cursor-cli", importPath: "runme_harbor.runme_agents:RunmeCursorCli"},
 	{name: "openclaw", importPath: "runme_harbor.runme_agents:RunmeOpenClaw"},
 }
@@ -120,6 +120,13 @@ func (b harborRunArgsBuilder) environmentArgs() ([]string, error) {
 func (b harborRunArgsBuilder) extraArgs() []string {
 	args := append([]string(nil), b.passthrough...)
 	for _, kwarg := range b.opts.AgentKwargs {
+		name, _, _ := strings.Cut(kwarg, "=")
+		if strings.TrimSpace(name) == "route_oauth_credentials" && usesRunmeEnvironment(b.opts.Env) {
+			spec, ok := runmeAgentByName(b.opts.Agent)
+			if ok && !spec.routeOAuthCredentials {
+				continue
+			}
+		}
 		args = append(args, "--agent-kwarg", kwarg)
 	}
 	for _, env := range b.opts.AgentEnv {
@@ -135,8 +142,9 @@ func (b harborRunArgsBuilder) extraArgs() []string {
 }
 
 type runmeAgentSpec struct {
-	name       string
-	importPath string
+	name                  string
+	importPath            string
+	routeOAuthCredentials bool
 }
 
 func (s runmeAgentSpec) HarborArgs() []string {

--- a/internal/harbor/eval_test.go
+++ b/internal/harbor/eval_test.go
@@ -572,6 +572,7 @@ func TestRunEvalDelegatesAgentKwargs(t *testing.T) {
 	path := t.TempDir()
 	var calls []recordedCommand
 	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.Agent = "codex"
 	opts.AgentKwargs = []string{"reasoning_effort=xhigh", "sandbox_mode=workspace-write", "route_oauth_credentials=false"}
 
 	err := NewEvalRunner(opts).Run([]string{path})
@@ -585,7 +586,7 @@ func TestRunEvalDelegatesAgentKwargs(t *testing.T) {
 		mustAbs(t, path),
 		"--jobs-dir", defaultJobsDir(t),
 		"--env", runmeEnvironmentImportPath,
-		"--agent", "oracle",
+		"--agent", "runme_harbor.runme_agents:RunmeCodex",
 		"-y",
 		"--n-concurrent", "1",
 		"--agent-kwarg", "reasoning_effort=xhigh",
@@ -594,6 +595,28 @@ func TestRunEvalDelegatesAgentKwargs(t *testing.T) {
 	}
 	if !reflect.DeepEqual(calls[1].args, want) {
 		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+}
+
+func TestRunEvalIgnoresOAuthRoutingPolicyForUnsupportedRunmeAgents(t *testing.T) {
+	for _, agent := range []string{"oracle", "nop", "cursor-cli", "openclaw"} {
+		t.Run(agent, func(t *testing.T) {
+			path := t.TempDir()
+			var calls []recordedCommand
+			opts := testEvalOptions(t, &calls, io.Discard)
+			opts.Agent = agent
+			opts.AgentKwargs = []string{"route_oauth_credentials=true"}
+
+			if err := NewEvalRunner(opts).Run([]string{path}); err != nil {
+				t.Fatal(err)
+			}
+
+			for _, arg := range calls[1].args {
+				if arg == "route_oauth_credentials=true" {
+					t.Fatalf("args = %#v", calls[1].args)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/harbor/eval_test.go
+++ b/internal/harbor/eval_test.go
@@ -572,7 +572,7 @@ func TestRunEvalDelegatesAgentKwargs(t *testing.T) {
 	path := t.TempDir()
 	var calls []recordedCommand
 	opts := testEvalOptions(t, &calls, io.Discard)
-	opts.AgentKwargs = []string{"reasoning_effort=xhigh", "sandbox_mode=workspace-write"}
+	opts.AgentKwargs = []string{"reasoning_effort=xhigh", "sandbox_mode=workspace-write", "route_oauth_credentials=false"}
 
 	err := NewEvalRunner(opts).Run([]string{path})
 	if err != nil {
@@ -590,9 +590,22 @@ func TestRunEvalDelegatesAgentKwargs(t *testing.T) {
 		"--n-concurrent", "1",
 		"--agent-kwarg", "reasoning_effort=xhigh",
 		"--agent-kwarg", "sandbox_mode=workspace-write",
+		"--agent-kwarg", "route_oauth_credentials=false",
 	}
 	if !reflect.DeepEqual(calls[1].args, want) {
 		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+}
+
+func TestRunEvalRejectsInvalidOAuthRoutingPolicy(t *testing.T) {
+	path := t.TempDir()
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.AgentKwargs = []string{"route_oauth_credentials=yes"}
+
+	err := NewEvalRunner(opts).Run([]string{path})
+	if err == nil || !strings.Contains(err.Error(), "route_oauth_credentials agent kwarg must be true or false") {
+		t.Fatalf("error = %v", err)
 	}
 }
 

--- a/internal/harbor/eval_test.go
+++ b/internal/harbor/eval_test.go
@@ -624,6 +624,51 @@ func TestRunEvalDelegatesAgentEnv(t *testing.T) {
 	}
 }
 
+func TestRunEvalDelegatesVerifierEnvAndDefaults(t *testing.T) {
+	path := t.TempDir()
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.VerifierEnv = []string{"OPENAI_BASE_URL=https://router.test/v1"}
+	opts.VerifierEnvDefault = []string{"RUNME_TEST_VERIFIER_KEY=managed-key"}
+
+	err := NewEvalRunner(opts).Run([]string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"run",
+		"--path", mustAbs(t, path),
+		"--jobs-dir", defaultJobsDir(t),
+		"--env", runmeEnvironmentImportPath,
+		"--agent", "oracle",
+		"-y",
+		"--n-concurrent", "1",
+		"--verifier-env", "OPENAI_BASE_URL=https://router.test/v1",
+	}
+	if !reflect.DeepEqual(calls[1].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+	if got := envValue(calls[1].env, "RUNME_TEST_VERIFIER_KEY"); got != "managed-key" {
+		t.Fatalf("RUNME_TEST_VERIFIER_KEY = %q, want managed-key", got)
+	}
+}
+
+func TestRunEvalVerifierEnvDefaultPreservesHostValue(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "host-key")
+	path := t.TempDir()
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.VerifierEnvDefault = []string{"OPENAI_API_KEY=managed-key"}
+
+	if err := NewEvalRunner(opts).Run([]string{path}); err != nil {
+		t.Fatal(err)
+	}
+	if got := envValue(calls[1].env, "OPENAI_API_KEY"); got != "host-key" {
+		t.Fatalf("OPENAI_API_KEY = %q, want host-key", got)
+	}
+}
+
 func TestRunEvalPreservesPassthroughModel(t *testing.T) {
 	path := t.TempDir()
 	var calls []recordedCommand


### PR DESCRIPTION
## Summary

- resolve native, indeterminate, explicit-key, and managed-fallback authentication in the Runme-owned Codex, Claude Code, and Antigravity wrappers
- add the boolean `route_oauth_credentials` wrapper kwarg, defaulting to `false`
- bypass router base URLs for native or indeterminate OAuth by default, while preserving explicit opt-in routing
- keep explicit API keys and `RUNME_ROUTER_FALLBACK_*` keys on the managed router path
- use Codex's built-in provider for native OAuth and a custom HTTP Responses provider for key-backed routing
- derive Claude's model argument from the effective route and isolate its native-auth probe from inherited verifier credentials
- remove both Google router base URLs for Antigravity native-auth bypass
- preserve verifier environment isolation and managed verifier routing
- validate the OAuth-routing kwarg at the Runme CLI boundary
- keep OAuth-routing capabilities in Runme's agent registry and discard the policy for agents that do not implement it

## Tests

- Harbor integration suite: 151 passed
- focused wrapper policy tests: 49 passed
- `ruff check` and `ruff format` on touched Harbor files
- `go test ./internal/harbor/...`
- `runme run check test`

Draft for review; no merge requested yet.