### PR TITLE
fix(harbor): enable Codex router websockets

### DIFF
--- a/integrations/harbor/src/runme_harbor/runme_agents.py
+++ b/integrations/harbor/src/runme_harbor/runme_agents.py
@@ -572,7 +572,7 @@ class RunmeCodex(Codex):
             (f"{provider}.wire_api", "responses"),
         )
         args = "".join(f"-c {_config_arg(key, value)} " for key, value in settings)
-        return f"{args}-c {provider}.supports_websockets=false "
+        return f"{args}-c {provider}.supports_websockets=true "
 
     def _native_router_args(self) -> str:
         base_url = self._get_env("OPENAI_BASE_URL")

--- a/integrations/harbor/tests/test_runme_codex.py
+++ b/integrations/harbor/tests/test_runme_codex.py
@@ -89,7 +89,7 @@ def test_runme_codex_routes_through_process_local_base_url(
     assert "model_providers.runme_router.base_url" in command
     assert "model_providers.runme_router.env_key" in command
     assert "model_providers.runme_router.wire_api" in command
-    assert "model_providers.runme_router.supports_websockets=false" in command
+    assert "model_providers.runme_router.supports_websockets=true" in command
     assert '\\"quoted\\"' in command
     assert "OPENAI_BASE_URL" not in command
 
@@ -237,7 +237,7 @@ def test_runme_codex_promoted_fallback_keeps_router_base_url(
     command, env = calls[0]
     assert "model_provider" in command
     assert "model_providers.runme_router.base_url" in command
-    assert "model_providers.runme_router.supports_websockets=false" in command
+    assert "model_providers.runme_router.supports_websockets=true" in command
     assert "unset OPENAI_API_KEY OPENAI_BASE_URL\n" not in command
     assert (env or {}).get("OPENAI_API_KEY") == "fallback-key"
 


### PR DESCRIPTION
## Summary

- enable Responses WebSocket transport for the key-backed `runme_router` Codex provider
- retain the custom provider so managed API-key routing remains isolated from cached ChatGPT OAuth credentials
- update the Codex wrapper policy assertions

## Root cause

Runme disabled WebSockets on its custom Codex router provider as a workaround for the Visr Responses WebSocket proxy closing upstream connections before completion. The Visr proxy now accepts both WebSocket legs, and an end-to-end eval through `runme_router` completed without reconnects or HTTPS fallback.

## Validation

- `uv run pytest tests/test_runme_codex.py` (17 passed)
- `uv run ruff check src/runme_harbor/runme_agents.py tests/test_runme_codex.py`
- `uv run ruff format --check src/runme_harbor/runme_agents.py tests/test_runme_codex.py`
- `runme run check test`

## Dependency

Deploy the corresponding Visr WebSocket proxy fix before releasing this change: https://github.com/sourishkrout/visr/pull/382